### PR TITLE
FACES-2614 Fix facesViewIdRenderer parameter set so it isn't cleared when there aren't parameters

### DIFF
--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/context/url/internal/BridgeBookmarkableURLImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/context/url/internal/BridgeBookmarkableURLImpl.java
@@ -86,8 +86,8 @@ public class BridgeBookmarkableURLImpl extends BridgeURLInternalBase {
 				(portletRequestPhase == Bridge.PortletPhase.RESOURCE_PHASE)) {
 
 			baseURL = createRenderURL(uri);
-			baseURL.setParameter(viewIdRenderParameterName, viewId);
 			baseURL.setParameters(getParameterMap());
+			baseURL.setParameter(viewIdRenderParameterName, viewId);
 		}
 
 		// Otherwise, log an error.


### PR DESCRIPTION
Hi @ngriffin7a, I think this could be safely backported to all branches.

Thanks!
