### PR TITLE
FACES-2686 Avoid IllegalStateException by not adding a parameter with an array of null values

### DIFF
--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/internal/BridgeURLBase.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/internal/BridgeURLBase.java
@@ -444,7 +444,9 @@ public abstract class BridgeURLBase implements BridgeURL {
 				if (!modeChanged) {
 
 					String contextRelativePath = bridgeURI.getContextRelativePath(contextPath);
-					toStringParameters.add(new URIParameter(getViewIdParameterName(), contextRelativePath));
+					if (contextRelativePath != null) {
+						toStringParameters.add(new URIParameter(getViewIdParameterName(), contextRelativePath));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Hi @ngriffin7a. Since https://issues.liferay.com/browse/FACES-2654 now all URL can create friendly URL for Liferay. As these friendly URL uses LiferayBaseURLFriendlyImpl, and this delegates to container PortletURL implementation, and portlet API says that parameter array values should have to be String, it will throw an IllegalStateException if any of the array values is null.

Previously we were adding null values for facesViewId parameter on resource URLs, which I think is not correct anyway.

I thought on fixing that in LiferayBaseURLFriendlyImpl instead, but I think that will only hide the actual problem, so IMO it's better to keep this failing whenever someone adds a null value in a portletURL so we are aware of that.

I think it's completely fine to backport to all branches.
