### PR TITLE
FACES-2696 Utilize Portlet 3.0 dynamic resource dependency feature (add TCK test)FACES-2974 Some children of jsf <head> components are not written to the response

### DIFF
--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/context/internal/PortalContextBridgeImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/context/internal/PortalContextBridgeImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,9 @@ public class PortalContextBridgeImpl extends PortalContextWrapper {
 	@Override
 	public String getProperty(String name) {
 
-		if (BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT.equals(name) ||
+		if (PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT.equals(name) ||
+				BridgePortalContext.ADD_ELEMENT_TO_HEAD_SUPPORT.equals(name) ||
+				BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT.equals(name) ||
 				BridgePortalContext.ADD_SCRIPT_TEXT_TO_HEAD_SUPPORT.equals(name) ||
 				BridgePortalContext.ADD_STYLE_SHEET_RESOURCE_TO_HEAD_SUPPORT.equals(name) ||
 				BridgePortalContext.ADD_STYLE_SHEET_TEXT_TO_HEAD_SUPPORT.equals(name)) {
@@ -74,7 +76,13 @@ public class PortalContextBridgeImpl extends PortalContextWrapper {
 			PartialViewContext partialViewContext = facesContext.getPartialViewContext();
 
 			if ((partialViewContext == null) || !partialViewContext.isAjaxRequest()) {
-				return getWrapped().getProperty(PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT);
+
+				if (PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT.equals(name)) {
+					return getWrapped().getProperty(PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT);
+				}
+				else {
+					return "true";
+				}
 			}
 			else {
 				return null;

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/BodyRendererBridgeImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/BodyRendererBridgeImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.liferay.faces.bridge.renderkit.html_basic.internal;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,9 +43,6 @@ import com.liferay.faces.util.application.ResourceUtil;
  */
 public class BodyRendererBridgeImpl extends RendererWrapper {
 
-	// Package-Private Constants
-	/* package-private */ static final String STYLE_CLASS_PORTLET_BODY = "liferay-faces-bridge-body";
-
 	// Private Members
 	private Renderer wrappedBodyRenderer;
 
@@ -64,8 +60,9 @@ public class BodyRendererBridgeImpl extends RendererWrapper {
 	@SuppressWarnings("unchecked")
 	public void encodeBegin(FacesContext facesContext, UIComponent uiComponent) throws IOException {
 
-		ResponseWriter responseWriter = facesContext.getResponseWriter();
-		ResponseWriterBridgeBodyImpl responseWriterPortletBodyImpl = new ResponseWriterBridgeBodyImpl(responseWriter);
+		ResponseWriter originalResponseWriter = facesContext.getResponseWriter();
+		ResponseWriterBridgeBodyImpl responseWriterPortletBodyImpl = new ResponseWriterBridgeBodyImpl(
+				originalResponseWriter);
 		facesContext.setResponseWriter(responseWriterPortletBodyImpl);
 		super.encodeBegin(facesContext, uiComponent);
 
@@ -79,10 +76,8 @@ public class BodyRendererBridgeImpl extends RendererWrapper {
 		// clue-in the developer that a <div> was rendered instead of <body>. If styleClass is not null, then the
 		// responseWriterBridgeBodyImpl will append STYLE_CLASS_PORTLET_BODY to the specified styleClass.
 		if (styleClass == null) {
-			responseWriterPortletBodyImpl.writeAttribute("class", STYLE_CLASS_PORTLET_BODY, "styleClass");
+			responseWriterPortletBodyImpl.writeAttribute("class", RenderKitUtil.STYLE_CLASS_PORTLET_BODY, "styleClass");
 		}
-
-		facesContext.setResponseWriter(responseWriter);
 
 		// Render each of the head resources that were not renderable in the head section into the top of the portlet
 		// body (the outer <div> of the portlet markup). This happens when the portlet container may not support adding
@@ -94,17 +89,8 @@ public class BodyRendererBridgeImpl extends RendererWrapper {
 		// loaded before the portlet body is rendered.
 		Map<Object, Object> facesContextAttributes = facesContext.getAttributes();
 		List<UIComponent> headResourcesToRenderInBody = (List<UIComponent>) facesContextAttributes.get(
-				HeadRendererBridgeImpl.HEAD_RESOURCES_TO_RENDER_IN_BODY);
-
-		HeadManagedBean headManagedBean = HeadManagedBean.getInstance(facesContext);
-		Set<String> headResourceIds;
-
-		if (headManagedBean == null) {
-			headResourceIds = new HashSet<String>();
-		}
-		else {
-			headResourceIds = headManagedBean.getHeadResourceIds();
-		}
+				RenderKitUtil.HEAD_RESOURCES_TO_RENDER_IN_BODY);
+		Set<String> headResourceIds = RenderKitUtil.getHeadResourceIds(facesContext);
 
 		// Note: If <style> elements or <link rel="stylesheet"> elements are not able to be rendered in the head, they
 		// will be relocated to the <body>. However, because those elements are only valid in the <head> section, the
@@ -121,18 +107,21 @@ public class BodyRendererBridgeImpl extends RendererWrapper {
 			// if necessary), we do not need to track them when they are rendered to the body section. However, scripts
 			// cannot be unloaded, so relocated scripts rendered in the body section must be tracked as if they were
 			// rendered in the <head> section so that they are not loaded multiple times.
-			if (HeadRendererBridgeImpl.isScriptResource(headResource)) {
+			if (RenderKitUtil.isScriptResource(headResource)) {
 				headResourceIds.add(ResourceUtil.getResourceId(headResource));
 			}
 		}
+
+		facesContext.setResponseWriter(originalResponseWriter);
 	}
 
 	@Override
 	public void encodeEnd(FacesContext facesContext, UIComponent uiComponent) throws IOException {
 
 		ResponseWriter originalResponseWriter = facesContext.getResponseWriter();
-		ResponseWriter responseWriter = new ResponseWriterBridgeBodyImpl(originalResponseWriter);
-		facesContext.setResponseWriter(responseWriter);
+		ResponseWriterBridgeBodyImpl responseWriterPortletBodyImpl = new ResponseWriterBridgeBodyImpl(
+				originalResponseWriter);
+		facesContext.setResponseWriter(responseWriterPortletBodyImpl);
 		super.encodeEnd(facesContext, uiComponent);
 		facesContext.setResponseWriter(originalResponseWriter);
 	}

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/RenderKitBridgeImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/RenderKitBridgeImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,6 @@ import com.liferay.faces.util.product.ProductFactory;
  */
 public class RenderKitBridgeImpl extends RenderKitBridgeImplCompat {
 
-	// Package-Private Constants
-	/* package-private */ static final String SCRIPT_RENDERER_TYPE = "javax.faces.resource.Script";
-	/* package-private */ static final String STYLESHEET_RENDERER_TYPE = "javax.faces.resource.Stylesheet";
-
 	// Private Constants
 	private static final boolean ICEFACES_DETECTED = ProductFactory.getProduct(Product.Name.ICEFACES).isDetected();
 	private static final String JAVAX_FACES_BODY = "javax.faces.Body";
@@ -80,7 +76,8 @@ public class RenderKitBridgeImpl extends RenderKitBridgeImplCompat {
 			else if (JAVAX_FACES_BODY.equals(rendererType)) {
 				renderer = new BodyRendererBridgeImpl(renderer);
 			}
-			else if (SCRIPT_RENDERER_TYPE.equals(rendererType) || STYLESHEET_RENDERER_TYPE.equals(rendererType)) {
+			else if (RenderKitUtil.SCRIPT_RENDERER_TYPE.equals(rendererType) ||
+					RenderKitUtil.STYLESHEET_RENDERER_TYPE.equals(rendererType)) {
 				renderer = new ResourceRendererBridgeImpl(renderer);
 			}
 		}

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/RenderKitUtil.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/RenderKitUtil.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.renderkit.html_basic.internal;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public final class RenderKitUtil {
+
+	// Package-Private Constants
+	/* package-private */ static final String HEAD_RESOURCES_TO_RENDER_IN_BODY = "headResourcesToRenderInBody";
+	/* package-private */ static final String SCRIPT_RENDERER_TYPE = "javax.faces.resource.Script";
+	/* package-private */ static final String STYLE_CLASS_PORTLET_BODY = "liferay-faces-bridge-body";
+	/* package-private */ static final String STYLESHEET_RENDERER_TYPE = "javax.faces.resource.Stylesheet";
+
+	private RenderKitUtil() {
+		throw new AssertionError();
+	}
+
+	/* package-private */ static Set<String> getHeadResourceIds(FacesContext facesContext) {
+
+		HeadManagedBean headManagedBean = HeadManagedBean.getInstance(facesContext);
+		Set<String> headResourceIds;
+
+		if (headManagedBean == null) {
+			headResourceIds = new HashSet<String>();
+		}
+		else {
+			headResourceIds = headManagedBean.getHeadResourceIds();
+		}
+
+		return headResourceIds;
+	}
+
+	/* package-private */ static boolean isScriptResource(UIComponent componentResource) {
+
+		Map<String, Object> componentResourceAttributes = componentResource.getAttributes();
+		String resourceName = (String) componentResourceAttributes.get("name");
+
+		return (resourceName != null) && resourceName.endsWith("js");
+	}
+
+	/* package-private */ static boolean isStyleSheetResource(UIComponent componentResource) {
+
+		Map<String, Object> componentResourceAttributes = componentResource.getAttributes();
+		String resourceName = (String) componentResourceAttributes.get("name");
+
+		return (resourceName != null) && resourceName.endsWith("css");
+	}
+}

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/ResponseWriterBridgeBodyImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/ResponseWriterBridgeBodyImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.liferay.faces.bridge.renderkit.html_basic.internal;
 
 import java.io.IOException;
+import java.util.Stack;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.ResponseWriter;
@@ -37,6 +38,7 @@ public class ResponseWriterBridgeBodyImpl extends ResponseWriterWrapper {
 	private static final Logger logger = LoggerFactory.getLogger(ResponseWriterBridgeBodyImpl.class);
 
 	// Private Data Members
+	private Stack<String> elementsStack = new Stack<String>();
 	private ResponseWriter wrapppedResponseWriter;
 
 	public ResponseWriterBridgeBodyImpl(ResponseWriter wrapppedResponseWriter) {
@@ -46,12 +48,23 @@ public class ResponseWriterBridgeBodyImpl extends ResponseWriterWrapper {
 	@Override
 	public void endElement(String name) throws IOException {
 
-		// It is forbidden for a portlet to render the <body> element, so instead, render a <div> element.
-		if ("body".equals(name)) {
-			name = "div";
+		if (!elementsStack.empty()) {
+			elementsStack.pop();
 		}
 
-		super.endElement(name);
+		// Supress illegal elements that have been migrated from the <head> section.
+		if ("title".equals(name) || "base".equals(name) || "meta".equals(name)) {
+			logger.warn("Suppressed writing of illegal element <{0}> in the document <body>.", name);
+		}
+		else {
+
+			// It is forbidden for a portlet to render the <body> element, so instead, render a <div> element.
+			if ("body".equals(name)) {
+				name = "div";
+			}
+
+			super.endElement(name);
+		}
 	}
 
 	@Override
@@ -62,34 +75,61 @@ public class ResponseWriterBridgeBodyImpl extends ResponseWriterWrapper {
 	@Override
 	public void startElement(String name, UIComponent component) throws IOException {
 
-		// It is forbidden for a portlet to render the <body> element, so instead, render a <div> element.
-		if ("body".equals(name)) {
-			name = "div";
-		}
+		elementsStack.push(name);
 
-		super.startElement(name, component);
+		// Supress illegal elements that have been migrated from the <head> section.
+		if ("title".equals(name) || "base".equals(name) || "meta".equals(name)) {
+			logger.warn("Suppressed writing of illegal element <{0}> in the document <body>.", name);
+		}
+		else {
+
+			// It is forbidden for a portlet to render the <body> element, so instead, render a <div> element.
+			if ("body".equals(name)) {
+				name = "div";
+			}
+
+			super.startElement(name, component);
+		}
 	}
 
 	@Override
 	public void writeAttribute(String name, Object value, String property) throws IOException {
 
-		if ("class".equals(name) && (value != null)) {
+		String currentElement = null;
 
-			String valueAsString = value.toString();
-
-			// Add a special CSS class name, BodyRendererBridgeImpl.STYLE_CLASS_PORTLET_BODY, in the rendered markup
-			// in order to clue-in the developer that a <div> was rendered instead of <body> if the styleClass does not
-			// already contain BodyRendererBridgeImpl.STYLE_CLASS_PORTLET_BODY.
-			if (!valueAsString.contains(BodyRendererBridgeImpl.STYLE_CLASS_PORTLET_BODY)) {
-				valueAsString = valueAsString.concat(" ").concat(BodyRendererBridgeImpl.STYLE_CLASS_PORTLET_BODY);
-			}
-
-			super.writeAttribute(name, valueAsString, property);
+		if (!elementsStack.empty()) {
+			currentElement = elementsStack.peek();
 		}
-		else if ("onload".equals(name) || "onunload".equals(name) || "role".equals(name) || "xmlns".equals(name)) {
-			logger.warn("Suppressed writing of illegal attribute {0} on portlet body <div>.", name);
+
+		if ("body".equals(currentElement) &&
+				("onload".equals(name) || "onunload".equals(name) || "role".equals(name) || "xmlns".equals(name))) {
+			logger.warn("Suppressed writing of illegal attribute \"{0}\" on portlet body <div>.", name);
+		}
+
+		// Supress illegal elements that have been migrated from the <head> section.
+		else if ("title".equals(currentElement) || "base".equals(currentElement) || "meta".equals(currentElement)) {
+			logger.warn("Suppressed writing of illegal element <{0}> in the document <body>.", currentElement);
 		}
 		else {
+
+			if ("body".equals(currentElement) && "class".equals(name)) {
+
+				String valueAsString = "";
+
+				if (value != null) {
+					valueAsString = value.toString();
+				}
+
+				// Add a special CSS class name, BodyRendererBridgeImpl.STYLE_CLASS_PORTLET_BODY, in the rendered markup
+				// in order to clue-in the developer that a <div> was rendered instead of <body> if the styleClass does
+				// not already contain BodyRendererBridgeImpl.STYLE_CLASS_PORTLET_BODY.
+				if (!valueAsString.contains(RenderKitUtil.STYLE_CLASS_PORTLET_BODY)) {
+					valueAsString = valueAsString.concat(" ").concat(RenderKitUtil.STYLE_CLASS_PORTLET_BODY);
+				}
+
+				value = valueAsString;
+			}
+
 			super.writeAttribute(name, value, property);
 		}
 	}

--- a/tck/bridge-tck-common/src/main/java/com/liferay/faces/bridge/tck/common/util/BridgeTCKUtil.java
+++ b/tck/bridge-tck-common/src/main/java/com/liferay/faces/bridge/tck/common/util/BridgeTCKUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,15 +26,13 @@ import javax.portlet.faces.BridgeUtil;
 public class BridgeTCKUtil {
 
 	public static boolean isHeaderOrRenderPhase(Bridge.PortletPhase portletPhase) {
-		return (Bridge.PortletPhase.HEADER_PHASE.equals(portletPhase) ||
-			Bridge.PortletPhase.RENDER_PHASE.equals(portletPhase));
+		return Bridge.PortletPhase.HEADER_PHASE.equals(portletPhase);
 	}
 
 	public static boolean isHeaderOrRenderPhase(FacesContext facesContext) {
 
 		Bridge.PortletPhase portletPhase = BridgeUtil.getPortletRequestPhase(facesContext);
 
-		return (Bridge.PortletPhase.HEADER_PHASE.equals(portletPhase) ||
-				Bridge.PortletPhase.RENDER_PHASE.equals(portletPhase));
+		return isHeaderOrRenderPhase(portletPhase);
 	}
 }

--- a/tck/bridge-tck-harness/src/main/java/com/liferay/faces/bridge/tck/harness/TckTestCase.java
+++ b/tck/bridge-tck-harness/src/main/java/com/liferay/faces/bridge/tck/harness/TckTestCase.java
@@ -181,7 +181,7 @@ public class TckTestCase extends IntegrationTesterBase {
 		}
 
 		Enumeration<?> tests = testProps.propertyNames();
-		Pattern extractTestNamePattern = Pattern.compile("chapter[0-9_]+Tests-([a-zA-Z]+)-portlet");
+		Pattern extractTestNamePattern = Pattern.compile("chapter[0-9_]+Tests-([_a-zA-Z0-9]+)-portlet");
 		Pattern testFilterPattern = null;
 		String testFilter = TestUtil.getSystemPropertyOrDefault("integration.test.filter", null);
 
@@ -502,7 +502,6 @@ public class TckTestCase extends IntegrationTesterBase {
 
 				browser.switchTo().frame("tck-iframe");
 				browser.waitForElementVisible("//body");
-
 				testPage(browser, false);
 			}
 			else {

--- a/tck/bridge-tck-harness/src/main/resources/tomcat_pluto/pluto-portal-driver-config.xml
+++ b/tck/bridge-tck-harness/src/main/resources/tomcat_pluto/pluto-portal-driver-config.xml
@@ -468,7 +468,7 @@ limitations under the License.
 			<portlet context="/com.liferay.faces.test.bridge.tck.main.portlet" name="chapter5_2Tests-isPostbackTest-portlet"/>
 		</page>
 		<page name="TestPage059" uri="/WEB-INF/themes/pluto-default-theme.jsp">
-			<portlet context="/com.liferay.faces.test.bridge.tck.main.portlet" name="chapter5_2Tests-renderPhaseListenerTest-portlet"/>
+			<portlet context="/com.liferay.faces.test.bridge.tck.main.portlet" name="chapter5_2Tests-headerPhaseListenerTest-portlet"/>
 		</page>
 		<page name="TestPage060" uri="/WEB-INF/themes/pluto-default-theme.jsp">
 			<portlet context="/com.liferay.faces.test.bridge.tck.main.portlet" name="chapter5_2Tests-eventPhaseListenerTest-portlet"/>
@@ -925,6 +925,12 @@ limitations under the License.
 		</page>
 		<page name="TestPage211" uri="/WEB-INF/themes/pluto-default-theme.jsp">
 			<portlet context="/com.liferay.faces.test.bridge.tck.main.portlet" name="chapter6_9Tests-usesConfiguredRenderKitTest-portlet"/>
+		</page>
+		<page name="TestPage212" uri="/WEB-INF/themes/pluto-default-theme.jsp">
+			<portlet context="/com.liferay.faces.test.bridge.tck.main.portlet" name="chapter5_2Tests-resourcesRenderedInHeadTest-portlet"/>
+		</page>
+		<page name="TestPage213" uri="/WEB-INF/themes/pluto-default-theme.jsp">
+			<portlet context="/com.liferay.faces.test.bridge.tck.main.portlet" name="chapter5_2Tests-markupRenderedInRenderPhaseTest-portlet"/>
 		</page>
 
 	</render-config>

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/filter/BridgePortletResponseFactoryTCKImpl.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/filter/BridgePortletResponseFactoryTCKImpl.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.tck.filter;
+
+import java.io.Serializable;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.EventRequest;
+import javax.portlet.EventResponse;
+import javax.portlet.HeaderRequest;
+import javax.portlet.HeaderResponse;
+import javax.portlet.PortletConfig;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+import javax.portlet.faces.BridgeConfig;
+import javax.portlet.faces.filter.BridgePortletResponseFactory;
+
+import com.liferay.faces.bridge.tck.common.Constants;
+import com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2.HeaderResponseResourcesRenderedInHeadTestImpl;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public class BridgePortletResponseFactoryTCKImpl extends BridgePortletResponseFactory implements Serializable {
+
+	// Serial Version UID
+	private static final long serialVersionUID = 2184921901586098823L;
+
+	// Private Constants
+	private static final String RESOURCES_RENDERED_IN_HEAD_TEST = "resourcesRenderedInHeadTest";
+
+	// Private Data Members
+	private BridgePortletResponseFactory wrappedBridgePortletResponseFactory;
+
+	public BridgePortletResponseFactoryTCKImpl(BridgePortletResponseFactory wrappedBridgePortletResponseFactory) {
+		this.wrappedBridgePortletResponseFactory = wrappedBridgePortletResponseFactory;
+	}
+
+	@Override
+	public ActionResponse getActionResponse(ActionRequest actionRequest, ActionResponse actionResponse,
+		PortletConfig portletConfig, BridgeConfig bridgeConfig) {
+		return wrappedBridgePortletResponseFactory.getActionResponse(actionRequest, actionResponse, portletConfig,
+				bridgeConfig);
+	}
+
+	@Override
+	public EventResponse getEventResponse(EventRequest eventRequest, EventResponse eventResponse,
+		PortletConfig portletConfig, BridgeConfig bridgeConfig) {
+		return wrappedBridgePortletResponseFactory.getEventResponse(eventRequest, eventResponse, portletConfig,
+				bridgeConfig);
+	}
+
+	@Override
+	public HeaderResponse getHeaderResponse(HeaderRequest headerRequest, HeaderResponse headerResponse,
+		PortletConfig portletConfig, BridgeConfig bridgeConfig) {
+
+		HeaderResponse returnHeaderResponse = wrappedBridgePortletResponseFactory.getHeaderResponse(headerRequest,
+				headerResponse, portletConfig, bridgeConfig);
+		String testName = (String) headerRequest.getAttribute(Constants.TEST_NAME);
+
+		if (RESOURCES_RENDERED_IN_HEAD_TEST.equals(testName)) {
+			returnHeaderResponse = new HeaderResponseResourcesRenderedInHeadTestImpl(returnHeaderResponse);
+		}
+
+		return returnHeaderResponse;
+	}
+
+	@Override
+	public RenderResponse getRenderResponse(RenderRequest renderRequest, RenderResponse renderResponse,
+		PortletConfig portletConfig, BridgeConfig bridgeConfig) {
+		return wrappedBridgePortletResponseFactory.getRenderResponse(renderRequest, renderResponse, portletConfig,
+				bridgeConfig);
+	}
+
+	@Override
+	public ResourceResponse getResourceResponse(ResourceRequest resourceRequest, ResourceResponse resourceResponse,
+		PortletConfig portletConfig, BridgeConfig bridgeConfig) {
+		return wrappedBridgePortletResponseFactory.getResourceResponse(resourceRequest, resourceResponse, portletConfig,
+				bridgeConfig);
+	}
+
+	@Override
+	public BridgePortletResponseFactory getWrapped() {
+		return wrappedBridgePortletResponseFactory;
+	}
+}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/renderkit/TestRenderKitFactory.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/renderkit/TestRenderKitFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import java.util.Iterator;
 import javax.faces.context.FacesContext;
 import javax.faces.render.RenderKit;
 import javax.faces.render.RenderKitFactory;
-
-import com.liferay.faces.util.render.internal.RenderKitUtilImpl;
 
 
 /**

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/HeaderResponseMarkupRenderedInRenderPhaseTestImpl.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/HeaderResponseMarkupRenderedInRenderPhaseTestImpl.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.portlet.HeaderResponse;
+import javax.portlet.filter.HeaderResponseWrapper;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public class HeaderResponseMarkupRenderedInRenderPhaseTestImpl extends HeaderResponseWrapper {
+
+	// Private Data Members
+	private PrintWriterMarkupRenderedInRenderPhaseTestImpl printWriterMarkupRenderedInRenderPhaseTestImpl;
+
+	public HeaderResponseMarkupRenderedInRenderPhaseTestImpl(HeaderResponse wrappedHeaderResponse) {
+		super(wrappedHeaderResponse);
+	}
+
+	public int getWriteMethodCalls() {
+
+		int writeMethodCalls = 0;
+
+		if (printWriterMarkupRenderedInRenderPhaseTestImpl != null) {
+			writeMethodCalls = printWriterMarkupRenderedInRenderPhaseTestImpl.getWriteMethodCalls();
+		}
+
+		return writeMethodCalls;
+	}
+
+	@Override
+	public PrintWriter getWriter() throws IOException {
+
+		if (printWriterMarkupRenderedInRenderPhaseTestImpl == null) {
+
+			PrintWriter printWriter = super.getWriter();
+			printWriterMarkupRenderedInRenderPhaseTestImpl = new PrintWriterMarkupRenderedInRenderPhaseTestImpl(
+					printWriter);
+		}
+
+		return printWriterMarkupRenderedInRenderPhaseTestImpl;
+	}
+}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/HeaderResponseResourcesRenderedInHeadTestImpl.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/HeaderResponseResourcesRenderedInHeadTestImpl.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.portlet.HeaderResponse;
+import javax.portlet.MimeResponse;
+import javax.portlet.filter.HeaderResponseWrapper;
+
+import org.w3c.dom.Element;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public class HeaderResponseResourcesRenderedInHeadTestImpl extends HeaderResponseWrapper {
+
+	// Private Constants
+	private static final String INLINE_SCRIPT_JS = "inlineScript_js";
+
+	// Package-Private Constants
+	/* package-private */ static final String[] TEST_HEAD_ELEMENT_IDS = new String[] {
+			"jsf.js", "resourcesRenderedInHeadTest.js", "resource1.js", "resource1.css", INLINE_SCRIPT_JS
+		};
+
+	// Private Data Members
+	private boolean addPropertyMarkupHeadElementCalled = false;
+	private Set<String> testHeadElementsAddedViaAddDependency = new HashSet<String>();
+
+	public HeaderResponseResourcesRenderedInHeadTestImpl(HeaderResponse headerResponse) {
+		super(headerResponse);
+	}
+
+	@Override
+	public void addDependency(String name, String scope, String version) {
+
+		for (String testHeadElementId : TEST_HEAD_ELEMENT_IDS) {
+
+			if (name.contains(testHeadElementId)) {
+				testHeadElementsAddedViaAddDependency.add(testHeadElementId);
+			}
+		}
+
+		super.addDependency(name, scope, version);
+	}
+
+	@Override
+	public void addDependency(String name, String scope, String version, String markup) {
+
+		for (String testHeadElementId : TEST_HEAD_ELEMENT_IDS) {
+
+			if ((markup.contains("src=\"") || markup.contains("href=\"")) &&
+					(name.contains(testHeadElementId) || markup.contains(testHeadElementId))) {
+				testHeadElementsAddedViaAddDependency.add(testHeadElementId);
+			}
+			else if (markup.contains(INLINE_SCRIPT_JS)) {
+				testHeadElementsAddedViaAddDependency.add(testHeadElementId);
+			}
+		}
+
+		super.addDependency(name, scope, version, markup);
+	}
+
+	@Override
+	public void addProperty(String key, Element element) {
+
+		if (MimeResponse.MARKUP_HEAD_ELEMENT.equals(key)) {
+			addPropertyMarkupHeadElementCalled = true;
+		}
+
+		super.addProperty(key, element);
+	}
+
+	@Override
+	public void addProperty(String key, String value) {
+
+		if (MimeResponse.MARKUP_HEAD_ELEMENT.equals(key)) {
+			addPropertyMarkupHeadElementCalled = true;
+		}
+
+		super.addProperty(key, value);
+	}
+
+	public Set<String> getTestHeadElementsAddedViaAddDependency() {
+		return testHeadElementsAddedViaAddDependency;
+	}
+
+	public boolean isAddPropertyMarkupHeadElementCalled() {
+		return addPropertyMarkupHeadElementCalled;
+	}
+}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/PortletMarkupRenderedInRenderPhaseTestImpl.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/PortletMarkupRenderedInRenderPhaseTestImpl.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.portlet.HeaderRequest;
+import javax.portlet.HeaderResponse;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import com.liferay.faces.bridge.tck.common.portlet.GenericFacesTestSuitePortlet;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public class PortletMarkupRenderedInRenderPhaseTestImpl extends GenericFacesTestSuitePortlet {
+
+	// Private Constants
+	private static final String HEADER_PHASE_WRITE_METHOD_CALLS = PortletMarkupRenderedInRenderPhaseTestImpl.class
+		.getName() + "_HEADER_WRITE_METHOD_CALLS";
+
+	@Override
+	public void render(RenderRequest renderRequest, RenderResponse renderResponse) throws PortletException,
+		IOException {
+
+		int headerWriteMethodCalls = (Integer) renderRequest.getAttribute(HEADER_PHASE_WRITE_METHOD_CALLS);
+		String testResultStatus;
+		String testResultDetail;
+
+		if (headerWriteMethodCalls == 0) {
+
+			RenderResponseMarkupRenderedInRenderPhaseTestImpl renderResponseMarkupRenderedInRenderPhaseTestImpl =
+				new RenderResponseMarkupRenderedInRenderPhaseTestImpl(renderResponse);
+			super.render(renderRequest, renderResponseMarkupRenderedInRenderPhaseTestImpl);
+
+			int renderWriteMethodCalls = renderResponseMarkupRenderedInRenderPhaseTestImpl.getWriteMethodCalls();
+
+			if (renderWriteMethodCalls > 0) {
+
+				testResultStatus = "SUCCESS";
+				testResultDetail =
+					"The bridge generated the response markup in the header phase and rendered the markup in the render phase. The bridge called the portlet PrintWriter's write method " +
+					renderWriteMethodCalls + " times.";
+			}
+			else {
+
+				testResultStatus = "FAILURE";
+				testResultDetail = "The bridge never wrote to the response during the render phase.";
+			}
+		}
+		else {
+
+			testResultStatus = "FAILURE";
+			testResultDetail = "The bridge incorrectly attempted to write to the response during the header phase.";
+		}
+
+		PrintWriter writer = renderResponse.getWriter();
+
+		//J-
+		writer
+			.append("<p>Test: <span id=\"markupRenderedInRenderPhaseTest-test-name\">markupRenderedInRenderPhaseTest</span></p>")
+			.append("<p>Status: <span id=\"markupRenderedInRenderPhaseTest-result-status\">").append(testResultStatus).append("</span></p>")
+			.append("<p>Detail: <span id=\"markupRenderedInRenderPhaseTest-result-detail\">").append(testResultDetail).append("</p>");
+		//J+
+	}
+
+	@Override
+	public void renderHeaders(HeaderRequest headerRequest, HeaderResponse headerResponse) throws PortletException,
+		IOException {
+
+		HeaderResponseMarkupRenderedInRenderPhaseTestImpl headerResponseMarkupRenderedInRenderPhaseTestImpl =
+			new HeaderResponseMarkupRenderedInRenderPhaseTestImpl(headerResponse);
+		super.renderHeaders(headerRequest, headerResponseMarkupRenderedInRenderPhaseTestImpl);
+
+		int writeMethodCalls = headerResponseMarkupRenderedInRenderPhaseTestImpl.getWriteMethodCalls();
+		headerRequest.setAttribute(HEADER_PHASE_WRITE_METHOD_CALLS, writeMethodCalls);
+	}
+
+}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/PrintWriterMarkupRenderedInRenderPhaseTestImpl.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/PrintWriterMarkupRenderedInRenderPhaseTestImpl.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2;
+
+import java.io.PrintWriter;
+import java.util.Locale;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public class PrintWriterMarkupRenderedInRenderPhaseTestImpl extends PrintWriter {
+
+	// Private Data Members
+	private int writeMethodCalls = 0;
+
+	public PrintWriterMarkupRenderedInRenderPhaseTestImpl(PrintWriter printWriter) {
+		super(printWriter);
+	}
+
+	@Override
+	public PrintWriter append(CharSequence csq) {
+
+		writeMethodCalls++;
+
+		return this;
+	}
+
+	@Override
+	public PrintWriter append(char c) {
+
+		writeMethodCalls++;
+
+		return this;
+	}
+
+	@Override
+	public PrintWriter append(CharSequence csq, int start, int end) {
+
+		writeMethodCalls++;
+
+		return this;
+	}
+
+	@Override
+	public boolean checkError() {
+		return false;
+	}
+
+	@Override
+	public void close() {
+		// no-op
+	}
+
+	@Override
+	public void flush() {
+		// no-op
+	}
+
+	@Override
+	public PrintWriter format(String format, Object... args) {
+
+		writeMethodCalls++;
+
+		return this;
+	}
+
+	@Override
+	public PrintWriter format(Locale l, String format, Object... args) {
+
+		writeMethodCalls++;
+
+		return this;
+	}
+
+	public int getWriteMethodCalls() {
+		return writeMethodCalls;
+	}
+
+	@Override
+	public void print(boolean b) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void print(char c) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void print(int i) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void print(long l) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void print(float f) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void print(double d) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void print(char[] s) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void print(String s) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void print(Object obj) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public PrintWriter printf(String format, Object... args) {
+
+		writeMethodCalls++;
+
+		return this;
+	}
+
+	@Override
+	public PrintWriter printf(Locale l, String format, Object... args) {
+
+		writeMethodCalls++;
+
+		return this;
+	}
+
+	@Override
+	public void println() {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(boolean x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(char x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(int x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(long x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(float x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(double x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(char[] x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(String x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void println(Object x) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void write(int c) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void write(char[] buf) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void write(String s) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void write(char[] buf, int off, int len) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+
+	@Override
+	public void write(String s, int off, int len) {
+
+		writeMethodCalls++;
+		// no-op
+	}
+}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/RenderResponseMarkupRenderedInRenderPhaseTestImpl.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/RenderResponseMarkupRenderedInRenderPhaseTestImpl.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.portlet.RenderResponse;
+import javax.portlet.filter.RenderResponseWrapper;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public class RenderResponseMarkupRenderedInRenderPhaseTestImpl extends RenderResponseWrapper {
+
+	// Private Data Members
+	private PrintWriterMarkupRenderedInRenderPhaseTestImpl printWriterMarkupRenderedInRenderPhaseTestImpl;
+
+	public RenderResponseMarkupRenderedInRenderPhaseTestImpl(RenderResponse wrappedRenderResponse) {
+		super(wrappedRenderResponse);
+	}
+
+	public int getWriteMethodCalls() {
+
+		int writeMethodCalls = 0;
+
+		if (printWriterMarkupRenderedInRenderPhaseTestImpl != null) {
+			writeMethodCalls = printWriterMarkupRenderedInRenderPhaseTestImpl.getWriteMethodCalls();
+		}
+
+		return writeMethodCalls;
+	}
+
+	@Override
+	public PrintWriter getWriter() throws IOException {
+
+		if (printWriterMarkupRenderedInRenderPhaseTestImpl == null) {
+
+			PrintWriter printWriter = super.getWriter();
+			printWriterMarkupRenderedInRenderPhaseTestImpl = new PrintWriterMarkupRenderedInRenderPhaseTestImpl(
+					printWriter);
+		}
+
+		return printWriterMarkupRenderedInRenderPhaseTestImpl;
+	}
+}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/ResourcesRenderedInHeadTestBean.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_5/section_5_2/ResourcesRenderedInHeadTestBean.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2;
+
+import java.util.Set;
+
+import javax.enterprise.context.RequestScoped;
+import javax.faces.bean.ManagedBean;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+import javax.portlet.PortletResponse;
+import javax.portlet.filter.PortletResponseWrapper;
+
+import static com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2.HeaderResponseResourcesRenderedInHeadTestImpl.TEST_HEAD_ELEMENT_IDS;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+@ManagedBean
+@RequestScoped
+public class ResourcesRenderedInHeadTestBean {
+
+	// Private Constants
+	private static final String TEST_HEAD_ELEMENT_IDS_JS_ARRAY;
+
+	static {
+
+		String testHeadElementIdsJSArray = "";
+
+		for (String testHeadElementId : HeaderResponseResourcesRenderedInHeadTestImpl.TEST_HEAD_ELEMENT_IDS) {
+
+			if (testHeadElementIdsJSArray.length() > 0) {
+				testHeadElementIdsJSArray += ", ";
+			}
+
+			testHeadElementIdsJSArray += "'" + testHeadElementId + "'";
+		}
+
+		TEST_HEAD_ELEMENT_IDS_JS_ARRAY = "[ " + testHeadElementIdsJSArray + " ]";
+	}
+
+	public String getTestHeadElementIdsJSArray() {
+		return TEST_HEAD_ELEMENT_IDS_JS_ARRAY;
+	}
+
+	public String getTestHeadElementsNotAddedViaAddDependency() {
+
+		String testHeadElementsAddedViaAddDependencyString = "";
+		Set<String> testHeadElementsAddedViaAddDependency = null;
+		FacesContext facesContext = FacesContext.getCurrentInstance();
+		ExternalContext externalContext = facesContext.getExternalContext();
+		PortletResponse portletResponse = (PortletResponse) externalContext.getResponse();
+
+		while (portletResponse instanceof PortletResponseWrapper) {
+
+			if (portletResponse instanceof HeaderResponseResourcesRenderedInHeadTestImpl) {
+
+				HeaderResponseResourcesRenderedInHeadTestImpl headerResponseResourcesRenderedInHeadTestImpl =
+					(HeaderResponseResourcesRenderedInHeadTestImpl) portletResponse;
+				testHeadElementsAddedViaAddDependency =
+					headerResponseResourcesRenderedInHeadTestImpl.getTestHeadElementsAddedViaAddDependency();
+
+				break;
+			}
+
+			PortletResponseWrapper portletResponseWrapper = (PortletResponseWrapper) portletResponse;
+			portletResponse = portletResponseWrapper.getResponse();
+		}
+
+		for (String testHeadElementId : TEST_HEAD_ELEMENT_IDS) {
+
+			if ((testHeadElementsAddedViaAddDependency == null) ||
+					!testHeadElementsAddedViaAddDependency.contains(testHeadElementId)) {
+
+				if (testHeadElementsAddedViaAddDependencyString.length() > 0) {
+					testHeadElementsAddedViaAddDependencyString += ", ";
+				}
+
+				testHeadElementsAddedViaAddDependencyString += testHeadElementId;
+			}
+		}
+
+		return testHeadElementsAddedViaAddDependencyString;
+	}
+
+	public boolean isAddPropertyMarkupHeadElementCalled() {
+
+		boolean addPropertyMarkupHeadElementCalled = false;
+		FacesContext facesContext = FacesContext.getCurrentInstance();
+		ExternalContext externalContext = facesContext.getExternalContext();
+		PortletResponse portletResponse = (PortletResponse) externalContext.getResponse();
+
+		while (portletResponse instanceof PortletResponseWrapper) {
+
+			if (portletResponse instanceof HeaderResponseResourcesRenderedInHeadTestImpl) {
+
+				HeaderResponseResourcesRenderedInHeadTestImpl headerResponseResourcesRenderedInHeadTestImpl =
+					(HeaderResponseResourcesRenderedInHeadTestImpl) portletResponse;
+				addPropertyMarkupHeadElementCalled =
+					headerResponseResourcesRenderedInHeadTestImpl.isAddPropertyMarkupHeadElementCalled();
+
+				break;
+			}
+
+			PortletResponseWrapper portletResponseWrapper = (PortletResponseWrapper) portletResponse;
+			portletResponse = portletResponseWrapper.getResponse();
+		}
+
+		return addPropertyMarkupHeadElementCalled;
+	}
+}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_6/section_6_1_3_1/Tests.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_6/section_6_1_3_1/Tests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1315,6 +1315,7 @@ public class Tests extends Object {
 		// This tests that we can encode a new mode in an actionURL
 		// done by navigation rule.
 		FacesContext ctx = FacesContext.getCurrentInstance();
+
 		if (BridgeTCKUtil.isHeaderOrRenderPhase(ctx)) {
 			Map<String, String> requestParameterMap = ctx.getExternalContext().getRequestParameterMap();
 
@@ -2690,13 +2691,13 @@ public class Tests extends Object {
 
 		if (charEncoding == null) {
 			testRunner.setTestResult(true,
-				"extCtx.getRequestCharacterEncoding() correctly returned null when called during the render phase.");
+				"extCtx.getRequestCharacterEncoding() correctly returned null when called during the header phase.");
 
 			return Constants.TEST_SUCCESS;
 		}
 		else {
 			testRunner.setTestResult(false,
-				"extCtx.getRequestCharacterEncoding() incorrectly returned non-null value when called during the render phase: " +
+				"extCtx.getRequestCharacterEncoding() incorrectly returned non-null value when called during the header phase: " +
 				charEncoding);
 
 			return Constants.TEST_FAILED;
@@ -2837,13 +2838,13 @@ public class Tests extends Object {
 
 		if (contentType == null) {
 			testRunner.setTestResult(true,
-				"extCtx.getRequestContentType() correctly returned null when called during the render phase.");
+				"extCtx.getRequestContentType() correctly returned null when called during the header phase.");
 
 			return Constants.TEST_SUCCESS;
 		}
 		else {
 			testRunner.setTestResult(false,
-				"extCtx.getRequestContentType() incorrectly returned non-null value when called during the render phase: " +
+				"extCtx.getRequestContentType() incorrectly returned non-null value when called during the header phase: " +
 				contentType);
 
 			return Constants.TEST_FAILED;
@@ -4055,19 +4056,19 @@ public class Tests extends Object {
 
 		if (!foundField1) {
 			testRunner.setTestResult(false,
-				"Failed Render Phase: extCtx.getRequestParameterMap() didn't properly expose the 'field1' query string parameter from the defaultViewId.");
+				"Failed Header Phase: extCtx.getRequestParameterMap() didn't properly expose the 'field1' query string parameter from the defaultViewId.");
 
 			return Constants.TEST_FAILED;
 		}
 		else if (!foundField2) {
 			testRunner.setTestResult(false,
-				"Failed Render Phase: extCtx.getRequestParameterMap() didn't properly expose the 'field2' query string parameter from the defaultViewId.");
+				"Failed Header Phase: extCtx.getRequestParameterMap() didn't properly expose the 'field2' query string parameter from the defaultViewId.");
 
 			return Constants.TEST_FAILED;
 		}
 		else {
 			testRunner.setTestResult(true,
-				"Passed RenderPhase: The getRequestParameterMap Map correctly exposed the query string fields in defaultViewId.");
+				"Passed Header Phase: The getRequestParameterMap Map correctly exposed the query string fields in defaultViewId.");
 
 			return Constants.TEST_SUCCESS;
 		}
@@ -4171,7 +4172,7 @@ public class Tests extends Object {
 
 			if (paramMap.get(ResponseStateManager.VIEW_STATE_PARAM) == null) {
 				testRunner.setTestResult(false,
-					"Render Phase extCtx.getRequestParameterMap() doesn't contain the ResponseStateManager.VIEW_STATE parameter. Test Result from the prior action phase was: " +
+					"Header Phase extCtx.getRequestParameterMap() doesn't contain the ResponseStateManager.VIEW_STATE parameter. Test Result from the prior action phase was: " +
 					testRunner.getTestResult());
 
 				return Constants.TEST_FAILED;
@@ -4196,19 +4197,19 @@ public class Tests extends Object {
 
 			if (foundField1) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterMap() incorrectly contains the value for the 'field1' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterMap() incorrectly contains the value for the 'field1' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else if (foundField2) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterMap() incorrectly contains the value for the 'field2' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterMap() incorrectly contains the value for the 'field2' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else {
 				testRunner.appendTestDetail(
-					"Passed RenderPhase: The getRequestParameterMap Map correctly excluded the submitted form fields from the render Phase.");
+					"Passed Header Phase: The getRequestParameterMap Map correctly excluded the submitted form fields from the Header Phase.");
 
 				return Constants.TEST_SUCCESS;
 			}
@@ -4310,26 +4311,26 @@ public class Tests extends Object {
 
 			if (!foundViewState) {
 				testRunner.setTestResult(false,
-					"Render phase extCtx.getRequestParameterNames() doesn't contain the ResponseStateManager.VIEW_STATE parameter. Test Result from the prior action Phase was: " +
+					"Header phase extCtx.getRequestParameterNames() doesn't contain the ResponseStateManager.VIEW_STATE parameter. Test Result from the prior action Phase was: " +
 					testRunner.getTestResult());
 
 				return Constants.TEST_FAILED;
 			}
 			else if (foundField1) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterName() incorrectly contains the 'field1' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterName() incorrectly contains the 'field1' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else if (foundField2) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterName() incorrectly contains the 'field2' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterName() incorrectly contains the 'field2' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else {
 				testRunner.appendTestDetail(
-					"Passed RenderPhase: The getRequestParameterName() correctly excluded the submitted form fields from the render phase.");
+					"Passed Header Phase: The getRequestParameterName() correctly excluded the submitted form fields from the header phase.");
 
 				return Constants.TEST_SUCCESS;
 			}
@@ -4365,19 +4366,19 @@ public class Tests extends Object {
 
 		if (!foundField1) {
 			testRunner.setTestResult(false,
-				"Failed Render Phase: extCtx.getRequestParameterNames() didn't properly expose the 'field1' query string parameter from the defaultViewId.");
+				"Failed Header Phase: extCtx.getRequestParameterNames() didn't properly expose the 'field1' query string parameter from the defaultViewId.");
 
 			return Constants.TEST_FAILED;
 		}
 		else if (!foundField2) {
 			testRunner.setTestResult(false,
-				"Failed Render Phase: extCtx.getRequestParameterNames() didn't properly expose the 'field2' query string parameter from the defaultViewId.");
+				"Failed Header Phase: extCtx.getRequestParameterNames() didn't properly expose the 'field2' query string parameter from the defaultViewId.");
 
 			return Constants.TEST_FAILED;
 		}
 		else {
 			testRunner.setTestResult(true,
-				"Passed RenderPhase: The getRequestParameterNames Iterator correctly exposed the query string fields in defaultViewId.");
+				"Passed Header Phase: The getRequestParameterNames Iterator correctly exposed the query string fields in defaultViewId.");
 
 			return Constants.TEST_SUCCESS;
 		}
@@ -4417,19 +4418,19 @@ public class Tests extends Object {
 
 			if (!foundField1) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterNames() didn't properly preserve the value for the 'field1' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterNames() didn't properly preserve the value for the 'field1' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else if (!foundField2) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterNames() didn't properly preserve the value for the 'field2' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterNames() didn't properly preserve the value for the 'field2' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else {
 				testRunner.setTestResult(true,
-					"Passed RenderPhase: The getRequestParameterNames Iterator correctly preserved the submitted form fields into the render phase.");
+					"Passed Header Phase: The getRequestParameterNames Iterator correctly preserved the submitted form fields into the header phase.");
 
 				return Constants.TEST_SUCCESS;
 			}
@@ -4472,19 +4473,19 @@ public class Tests extends Object {
 
 			if (!foundField1) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterMap() didn't properly preserve the value for the 'field1' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterMap() didn't properly preserve the value for the 'field1' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else if (!foundField2) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterMap() didn't properly preserve the value for the 'field2' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterMap() didn't properly preserve the value for the 'field2' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else {
 				testRunner.setTestResult(true,
-					"Passed RenderPhase: The getRequestParameterMap Map correctly preserved the submitted form fields into the render Phase.");
+					"Passed Header Phase: The getRequestParameterMap Map correctly preserved the submitted form fields into the Header Phase.");
 
 				return Constants.TEST_SUCCESS;
 			}
@@ -4592,7 +4593,7 @@ public class Tests extends Object {
 
 			if (paramMap.get(ResponseStateManager.VIEW_STATE_PARAM) == null) {
 				testRunner.setTestResult(false,
-					"Render Phase extCtx.getRequestParameterValuesMap() doesn't contain the ResponseStateManager.VIEW_STATE parameter. Test Result from the prior action phase was: " +
+					"Header Phase extCtx.getRequestParameterValuesMap() doesn't contain the ResponseStateManager.VIEW_STATE parameter. Test Result from the prior action phase was: " +
 					testRunner.getTestResult());
 
 				return Constants.TEST_FAILED;
@@ -4616,19 +4617,19 @@ public class Tests extends Object {
 
 			if (foundField1) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterValuesMap() incorrectly contains the value for the 'field1' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterValuesMap() incorrectly contains the value for the 'field1' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else if (foundField2) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterValuesMap() incorrectly contains the value for the 'field2' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterValuesMap() incorrectly contains the value for the 'field2' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else {
 				testRunner.appendTestDetail(
-					"Passed RenderPhase: The getRequestParameterValuesMap Map correctly excluded the submitted form fields from the render Phase.");
+					"Passed Header Phase: The getRequestParameterValuesMap Map correctly excluded the submitted form fields from the Header Phase.");
 
 				return Constants.TEST_SUCCESS;
 			}
@@ -4666,19 +4667,19 @@ public class Tests extends Object {
 
 		if (!foundField1) {
 			testRunner.setTestResult(false,
-				"Failed Render Phase: extCtx.getRequestParameterValuesMap() didn't properly expose the 'field1' query string parameter from the defaultViewId.");
+				"Failed Header Phase: extCtx.getRequestParameterValuesMap() didn't properly expose the 'field1' query string parameter from the defaultViewId.");
 
 			return Constants.TEST_FAILED;
 		}
 		else if (!foundField2) {
 			testRunner.setTestResult(false,
-				"Failed Render Phase: extCtx.getRequestParameterValuesMap() didn't properly expose the 'field2' query string parameter from the defaultViewId.");
+				"Failed Header Phase: extCtx.getRequestParameterValuesMap() didn't properly expose the 'field2' query string parameter from the defaultViewId.");
 
 			return Constants.TEST_FAILED;
 		}
 		else {
 			testRunner.setTestResult(true,
-				"Passed RenderPhase: The getRequestParameterValuesMap Map correctly exposed the query string fields in defaultViewId.");
+				"Passed Header Phase: The getRequestParameterValuesMap Map correctly exposed the query string fields in defaultViewId.");
 
 			return Constants.TEST_SUCCESS;
 		}
@@ -4719,19 +4720,19 @@ public class Tests extends Object {
 
 			if (!foundField1) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterValuesMap() didn't properly preserve the value for the 'field1' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterValuesMap() didn't properly preserve the value for the 'field1' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else if (!foundField2) {
 				testRunner.setTestResult(false,
-					"Failed Render Phase: extCtx.getRequestParameterValuesMap() didn't properly preserve the value for the 'field2' form parameter.");
+					"Failed Header Phase: extCtx.getRequestParameterValuesMap() didn't properly preserve the value for the 'field2' form parameter.");
 
 				return Constants.TEST_FAILED;
 			}
 			else {
 				testRunner.setTestResult(true,
-					"Passed RenderPhase: The getRequestParameterValuesMap Map correctly preserved the submitted form fields into the render Phase.");
+					"Passed Header Phase: The getRequestParameterValuesMap Map correctly preserved the submitted form fields into the Header Phase.");
 
 				return Constants.TEST_SUCCESS;
 			}
@@ -4754,13 +4755,13 @@ public class Tests extends Object {
 		// the value should be null
 		if (pathInfo == null) {
 			testRunner.setTestResult(true,
-				"Passed RenderPhase: extCtx.getRequestPathInfo() correctly returned a null value as the Faces servlet is extension mapped.");
+				"Passed Header Phase: extCtx.getRequestPathInfo() correctly returned a null value as the Faces servlet is extension mapped.");
 
 			return Constants.TEST_SUCCESS;
 		}
 		else {
 			testRunner.setTestResult(false,
-				"Failed Render Phase: extCtx.getRequestPathInfo() returned a non-null value though null was expected as the Faces servlet is extension mapped.");
+				"Failed Header Phase: extCtx.getRequestPathInfo() returned a non-null value though null was expected as the Faces servlet is extension mapped.");
 
 			return Constants.TEST_FAILED;
 		}
@@ -4786,14 +4787,14 @@ public class Tests extends Object {
 
 		if (servletPath.equalsIgnoreCase(viewId)) {
 			testRunner.setTestResult(true,
-				"Passed RenderPhase: extCtx.getRequestServletPath() correctly returned the unmapped (extension mapped) viewId: " +
+				"Passed Header Phase: extCtx.getRequestServletPath() correctly returned the unmapped (extension mapped) viewId: " +
 				servletPath);
 
 			return Constants.TEST_SUCCESS;
 		}
 		else {
 			testRunner.setTestResult(false,
-				"Failed Render Phase: extCtx.getRequestServletPath() returned something other than the the unmapped (extension mapped) viewId.  Expected: " +
+				"Failed Header Phase: extCtx.getRequestServletPath() returned something other than the the unmapped (extension mapped) viewId.  Expected: " +
 				viewId + " getRequestServletPath returned: " + servletPath);
 
 			return Constants.TEST_FAILED;
@@ -5909,13 +5910,13 @@ public class Tests extends Object {
 
 			// In portlet 1.0 there is no supprt for this -- so spec says ignore
 			testRunner.setTestResult(true,
-				"setRequestCharacterEncoding correctly didn't throw an exception when called during the render Phase.");
+				"setRequestCharacterEncoding correctly didn't throw an exception when called during the Header Phase.");
 
 			return Constants.TEST_SUCCESS;
 		}
 		catch (Exception e) {
 			testRunner.setTestResult(false,
-				"setRequestCharacterEncoding correctly didn't throw an exception when called during the render Phase.");
+				"setRequestCharacterEncoding correctly didn't throw an exception when called during the Header Phase.");
 
 			return Constants.TEST_FAILED;
 		}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_6/section_6_5_1/Tests.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_6/section_6_5_1/Tests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,8 +159,8 @@ public class Tests {
 		}
 
 		// HeaderRequest / RenderRequest
-		else
-		{
+		else {
+
 			try {
 
 				// JSF Implicit Objects
@@ -264,7 +264,7 @@ public class Tests {
 				// Things completed successfully
 				testRunner.setTestComplete(true);
 				testRunner.setTestResult(true,
-					"JSF EL impicit objects correctly resolved in both action and render phases.");
+					"JSF EL impicit objects correctly resolved in both action and header/render phases.");
 
 				return Constants.TEST_SUCCESS;
 			}

--- a/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_6/section_6_9/Tests.java
+++ b/tck/bridge-tck-main-portlet/src/main/java/com/liferay/faces/bridge/tck/tests/chapter_6/section_6_9/Tests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,7 +167,7 @@ public class Tests extends Object {
 
 			if (detail.length() == 0) {
 				testRunner.setTestResult(true,
-					"The portlet configured renderkit was correctly expressed as a request parameter (via the ExternalContext apis) in both the action and render phases.");
+					"The portlet configured renderkit was correctly expressed as a request parameter (via the ExternalContext apis) in both the action and header phases.");
 
 				return Constants.TEST_SUCCESS;
 			}

--- a/tck/bridge-tck-main-portlet/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tck/bridge-tck-main-portlet/src/main/webapp/WEB-INF/faces-config.xml
@@ -62,6 +62,9 @@
 		<render-kit-factory>com.liferay.faces.bridge.tck.renderkit.TestRenderKitFactory</render-kit-factory>
 		<faces-context-factory>com.liferay.faces.bridge.tck.common.util.faces.context.TCK_FacesContextFactoryImpl</faces-context-factory>
 		<lifecycle-factory>com.liferay.faces.bridge.tck.common.util.faces.application.TestSuiteLifecycleFactoryImpl</lifecycle-factory>
+		<factory-extension>
+			<bridge:bridge-portlet-response-factory>com.liferay.faces.bridge.tck.filter.BridgePortletResponseFactoryTCKImpl</bridge:bridge-portlet-response-factory>
+		</factory-extension>
 	</factory>
 	<managed-bean>
 		<managed-bean-name>chapter3Tests</managed-bean-name>

--- a/tck/bridge-tck-main-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml
+++ b/tck/bridge-tck-main-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml
@@ -337,7 +337,7 @@
 		<requires-namespaced-parameters>false</requires-namespaced-parameters>
 	</portlet>
 	<portlet>
-		<portlet-name>chapter5_2Tests-renderPhaseListenerTest-portlet</portlet-name>
+		<portlet-name>chapter5_2Tests-headerPhaseListenerTest-portlet</portlet-name>
 		<!-- JAVASERVERFACES-3031 -->
 		<requires-namespaced-parameters>false</requires-namespaced-parameters>
 	</portlet>
@@ -1099,6 +1099,16 @@
 	</portlet>
 	<portlet>
 		<portlet-name>chapter6_9Tests-usesConfiguredRenderKitTest-portlet</portlet-name>
+		<requires-namespaced-parameters>false</requires-namespaced-parameters>
+	</portlet>
+	<portlet>
+		<portlet-name>chapter5_2Tests-resourcesRenderedInHeadTest-portlet</portlet-name>
+		<!-- JAVASERVERFACES-3031 -->
+		<requires-namespaced-parameters>false</requires-namespaced-parameters>
+	</portlet>
+	<portlet>
+		<portlet-name>chapter5_2Tests-markupRenderedInRenderPhaseTest-portlet</portlet-name>
+		<!-- JAVASERVERFACES-3031 -->
 		<requires-namespaced-parameters>false</requires-namespaced-parameters>
 	</portlet>
 	<role-mapper>

--- a/tck/bridge-tck-main-portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/tck/bridge-tck-main-portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -1276,7 +1276,7 @@
 	</portlet>
 
 	<portlet>
-		<portlet-name>chapter5_2Tests-renderPhaseListenerTest-portlet</portlet-name>
+		<portlet-name>chapter5_2Tests-headerPhaseListenerTest-portlet</portlet-name>
 		<portlet-class>com.liferay.faces.bridge.tck.common.portlet.GenericFacesTestSuitePortlet</portlet-class>
 
 		<init-param>
@@ -1290,7 +1290,7 @@
 			<mime-type>text/html</mime-type>
 		</supports>
 		<portlet-info>
-			<title>chapter5_2Tests-renderPhaseListenerTest-portlet</title>
+			<title>chapter5_2Tests-headerPhaseListenerTest-portlet</title>
 		</portlet-info>
 	</portlet>
 
@@ -4954,6 +4954,38 @@
 		</supports>
 		<portlet-info>
 			<title>chapter6_9Tests-usesConfiguredRenderKitTest-portlet</title>
+		</portlet-info>
+	</portlet>
+
+	<portlet>
+		<portlet-name>chapter5_2Tests-resourcesRenderedInHeadTest-portlet</portlet-name>
+		<portlet-class>com.liferay.faces.bridge.tck.common.portlet.GenericFacesTestSuitePortlet</portlet-class>
+		<init-param>
+			<name>javax.portlet.faces.defaultViewId.view</name>
+			<value>/tests/resourcesRenderedInHeadTest.xhtml</value>
+		</init-param>
+		<expiration-cache>0</expiration-cache>
+		<supports>
+			<mime-type>text/html</mime-type>
+		</supports>
+		<portlet-info>
+			<title>chapter5_2Tests-resourcesRenderedInHeadTest-portlet</title>
+		</portlet-info>
+	</portlet>
+
+	<portlet>
+		<portlet-name>chapter5_2Tests-markupRenderedInRenderPhaseTest-portlet</portlet-name>
+		<portlet-class>com.liferay.faces.bridge.tck.tests.chapter_5.section_5_2.PortletMarkupRenderedInRenderPhaseTestImpl</portlet-class>
+		<init-param>
+			<name>javax.portlet.faces.defaultViewId.view</name>
+			<value>/tests/markupRenderedInRenderPhaseTest.xhtml</value>
+		</init-param>
+		<expiration-cache>0</expiration-cache>
+		<supports>
+			<mime-type>text/html</mime-type>
+		</supports>
+		<portlet-info>
+			<title>chapter5_2Tests-markupRenderedInRenderPhaseTest-portlet</title>
 		</portlet-info>
 	</portlet>
 

--- a/tck/bridge-tck-main-portlet/src/main/webapp/resources/test/resource1.css
+++ b/tck/bridge-tck-main-portlet/src/main/webapp/resources/test/resource1.css
@@ -1,0 +1,3 @@
+.example-css-class {
+	background: red;
+}

--- a/tck/bridge-tck-main-portlet/src/main/webapp/resources/test/resource1.js
+++ b/tck/bridge-tck-main-portlet/src/main/webapp/resources/test/resource1.js
@@ -1,0 +1,1 @@
+console.log('resource1.js');

--- a/tck/bridge-tck-main-portlet/src/main/webapp/resources/test/resourcesRenderedInHeadTest.js
+++ b/tck/bridge-tck-main-portlet/src/main/webapp/resources/test/resourcesRenderedInHeadTest.js
@@ -1,0 +1,81 @@
+(function() {
+
+	function getTestHeadElementId(element) {
+
+		var testHeadElementId = null;
+		var testHeadElementIds = window.getTestHeadElementIds();
+
+		for (var i = 0; i < testHeadElementIds.length; i++) {
+
+			if ((element.id && element.id.indexOf(testHeadElementIds[i]) > -1) || (element.src &&
+					element.src.indexOf('javax.faces.resource') > -1 &&
+					element.src.indexOf(testHeadElementIds[i]) > -1) ||
+					(element.href && element.href.indexOf('javax.faces.resource') > -1 &&
+					element.href.indexOf(testHeadElementIds[i]) > -1)) {
+
+				if ((element.src && element.src.indexOf('javax.faces.resource/') > -1) ||
+						(element.href && element.href.indexOf('javax.faces.resource/') > -1)) {
+					console.log('Warning: servlet mapped resource found.');
+				}
+				else {
+					testHeadElementId = testHeadElementIds[i];
+				}
+			}
+		}
+
+		return testHeadElementId;
+	}
+
+	window.onload = function () {
+
+		var actualTestHeadElementIds = [];
+		var head = document.getElementsByTagName('head')[0];
+		var headResources = Array.prototype.slice.call(head.getElementsByTagName('link'), 0);
+		headResources = headResources.concat(Array.prototype.slice.call(head.getElementsByTagName('style'), 0));
+		headResources = headResources.concat(Array.prototype.slice.call(head.getElementsByTagName('script'), 0));
+
+		for (var i = 0; i < headResources.length; i++) {
+
+			var testHeadElementId = getTestHeadElementId(headResources[i]);
+
+			if (testHeadElementId) {
+				actualTestHeadElementIds.push(testHeadElementId);
+			}
+		}
+
+		var resultsElement = document.getElementById('resourcesRenderedInHeadTestResults');
+
+		if (resultsElement) {
+
+			var testHeadElementIds = window.getTestHeadElementIds();
+			var resourcesNotRendered = '';
+
+			for (var i = 0; i < testHeadElementIds.length; i++) {
+
+				if (actualTestHeadElementIds.indexOf(testHeadElementIds[i]) === -1) {
+
+					if (resourcesNotRendered.length > 0) {
+						resourcesNotRendered += ', ';
+					}
+
+					resourcesNotRendered += testHeadElementIds[i];
+				}
+			}
+
+			var testResultStatus = 'SUCCESS';
+			var testResultDetail = 'Resources correctly rendered in the &lt;head&gt; section.';
+
+			if (resourcesNotRendered.length > 0) {
+
+				testResultStatus = 'FAILURE';
+				testResultDetail = 'The following resources were not rendered in the &lt;head&gt; section: ' +
+						resourcesNotRendered;
+			}
+
+			resultsElement.innerHTML =
+					'<p>Test: <span id="resourcesRenderedInHeadTest-test-name">resourcesRenderedInHeadTest</span></p>' +
+					'<p>Status: <span id="resourcesRenderedInHeadTest-result-status">' + testResultStatus +'</span></p>' +
+					'<p>Detail: <span id="resourcesRenderedInHeadTest-result-detail">' + testResultDetail + '</span></p>';
+		}
+	};
+})();

--- a/tck/bridge-tck-main-portlet/src/main/webapp/tests/markupRenderedInRenderPhaseTest.xhtml
+++ b/tck/bridge-tck-main-portlet/src/main/webapp/tests/markupRenderedInRenderPhaseTest.xhtml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<f:view xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+		xmlns:h="http://xmlns.jcp.org/jsf/html">
+	<h:head/>
+	<h:body>
+		<h:form>
+			<h:commandButton value="This view is never rendered.">
+				<f:ajax render="@form" />
+			</h:commandButton>
+		</h:form>
+	</h:body>
+</f:view>

--- a/tck/bridge-tck-main-portlet/src/main/webapp/tests/resourcesRenderedInHeadTest.xhtml
+++ b/tck/bridge-tck-main-portlet/src/main/webapp/tests/resourcesRenderedInHeadTest.xhtml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<f:view xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+		xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:portlet="http://xmlns.jcp.org/portlet_3_0"
+		xmlns:c="http://java.sun.com/jsp/jstl/core">
+	<h:head>
+		<h:outputScript library="test" name="resourcesRenderedInHeadTest.js" />
+		<portlet:resourceURL var="testResource1">
+			<portlet:param name="ln" value="test" />
+			<portlet:param name="javax.faces.resource" value="resource1.js" />
+		</portlet:resourceURL>
+		<script type="text/javascript" src="${testResource1}"></script>
+		<h:outputStylesheet library="test" name="resource1.css" />
+	</h:head>
+	<h:body>
+		<h:outputScript target="head">
+			// Set the id of this script since h:outputScript's id attribute is not rendered in the html.
+			var scripts = document.getElementsByTagName('script');
+			var currentScript = scripts[scripts.length - 1];
+			currentScript.id = 'inlineScript_js';
+
+			window.getTestHeadElementIds = function() {
+				return #{resourcesRenderedInHeadTestBean.testHeadElementIdsJSArray};
+			}
+		</h:outputScript>
+		<h:panelGroup rendered="#{!resourcesRenderedInHeadTestBean.addPropertyMarkupHeadElementCalled and resourcesRenderedInHeadTestBean.testHeadElementsNotAddedViaAddDependency == ''}">
+			<div id="resourcesRenderedInHeadTestResults"></div>
+		</h:panelGroup>
+		<h:panelGroup
+			rendered="#{resourcesRenderedInHeadTestBean.addPropertyMarkupHeadElementCalled or resourcesRenderedInHeadTestBean.testHeadElementsNotAddedViaAddDependency != ''}">
+			<p>Test: <span id="resourcesRenderedInHeadTest-test-name">resourcesRenderedInHeadTest</span></p>
+			<p>Status: <span id="resourcesRenderedInHeadTest-result-status">FAILURE</span></p>
+			<p>Detail: <span id="resourcesRenderedInHeadTest-result-detail">
+				<h:outputText rendered="#{resourcesRenderedInHeadTestBean.addPropertyMarkupHeadElementCalled}"
+					value="The bridge incorrectly attempted to add an element to the &lt;head&gt; section via headerRequest.addProperty(MimeResponse.MARKUP_HEAD_ELEMENT, value)." />
+				<h:outputText rendered="#{resourcesRenderedInHeadTestBean.testHeadElementsNotAddedViaAddDependency != ''}"
+					value=" The bridge failed to call headerRequest.addDependency() for the following resources: #{resourcesRenderedInHeadTestBean.testHeadElementsNotAddedViaAddDependency}" />
+			</span></p>
+		</h:panelGroup>
+		<h:form>
+			<!-- Only included to test that component resources like jsf.js are included in the head section. -->
+			<h:commandButton class="run-ppr-button" value="Run Test">
+				<f:ajax render="@form"/>
+			</h:commandButton>
+		</h:form>
+	</h:body>
+</f:view>

--- a/tck/bridge-tck-main-portlet/src/test/resources/liferay-tests.xml
+++ b/tck/bridge-tck-main-portlet/src/test/resources/liferay-tests.xml
@@ -59,7 +59,7 @@
 	<entry key="testpage056">chapter5_2Tests-portletPhaseRemovedActionTest-portlet</entry>
 	<entry key="testpage057">chapter5_2Tests-bridgeSetsContentTypeTest-portlet</entry>
 	<entry key="testpage058">chapter5_2Tests-isPostbackTest-portlet</entry>
-	<entry key="testpage059">chapter5_2Tests-renderPhaseListenerTest-portlet</entry>
+	<entry key="testpage059">chapter5_2Tests-headerPhaseListenerTest-portlet</entry>
 	<entry key="testpage060">chapter5_2Tests-eventPhaseListenerTest-portlet</entry>
 	<entry key="testpage061">chapter5_2Tests-eventScopeRestoredTest-portlet</entry>
 	<entry key="testpage062">chapter5_2Tests-eventScopeNotRestoredRedirectTest-portlet</entry>
@@ -212,4 +212,6 @@
 	<entry key="testpage209">chapter6_7Tests-restoredViewStateParameterTest-portlet</entry>
 	<entry key="testpage210">chapter6_7Tests-setsIsPostbackAttributeTest-portlet</entry>
 	<entry key="testpage211">chapter6_9Tests-usesConfiguredRenderKitTest-portlet</entry>
+	<entry key="testPage212">chapter5_2Tests-resourcesRenderedInHeadTest-portlet</entry>
+	<entry key="TestPage213">chapter5_2Tests-markupRenderedInRenderPhaseTest-portlet</entry>
 </properties>

--- a/tck/bridge-tck-main-portlet/src/test/resources/pluto-tests.xml
+++ b/tck/bridge-tck-main-portlet/src/test/resources/pluto-tests.xml
@@ -66,7 +66,7 @@ NOTE:
 	<entry key="TestPage056">chapter5_2Tests-portletPhaseRemovedActionTest-portlet</entry>
 	<entry key="TestPage057">chapter5_2Tests-bridgeSetsContentTypeTest-portlet</entry>
 	<entry key="TestPage058">chapter5_2Tests-isPostbackTest-portlet</entry>
-	<entry key="TestPage059">chapter5_2Tests-renderPhaseListenerTest-portlet</entry>
+	<entry key="TestPage059">chapter5_2Tests-headerPhaseListenerTest-portlet</entry>
 <!-- 	<entry key="TestPage060">chapter5_2Tests-eventPhaseListenerTest-portlet</entry> -->
 <!-- 	<entry key="TestPage061">chapter5_2Tests-eventScopeRestoredTest-portlet</entry> -->
 <!-- 	<entry key="TestPage062">chapter5_2Tests-eventScopeNotRestoredRedirectTest-portlet</entry> -->
@@ -219,4 +219,6 @@ NOTE:
 	<entry key="TestPage209">chapter6_7Tests-restoredViewStateParameterTest-portlet</entry>
 	<entry key="TestPage210">chapter6_7Tests-setsIsPostbackAttributeTest-portlet</entry>
 	<entry key="TestPage211">chapter6_9Tests-usesConfiguredRenderKitTest-portlet</entry>
+	<entry key="TestPage212">chapter5_2Tests-resourcesRenderedInHeadTest-portlet</entry>
+	<entry key="TestPage213">chapter5_2Tests-markupRenderedInRenderPhaseTest-portlet</entry>
 </properties>


### PR DESCRIPTION
@ngriffin7a, please merge this and backport to `5.x` **only**. I will send a PR for a backport to `4.x`/`3.x`.