### PR TITLE
FACES-3136 Setting required="true" for h:inputFile, bridge:inputFile, or alloy:inputFile has no effect

### DIFF
--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/component/inputfile/internal/HtmlInputFileRenderer.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/component/inputfile/internal/HtmlInputFileRenderer.java
@@ -15,6 +15,7 @@
  */
 package com.liferay.faces.bridge.component.inputfile.internal;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -22,6 +23,7 @@ import javax.faces.component.UIComponent;
 import javax.faces.component.html.HtmlInputFile;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
+import javax.faces.convert.ConverterException;
 import javax.faces.render.Renderer;
 import javax.portlet.PortletContext;
 import javax.portlet.PortletRequest;
@@ -79,27 +81,36 @@ public class HtmlInputFileRenderer extends DelegatingRendererBase {
 		if (uploadedFileMap != null) {
 
 			String clientId = uiComponent.getClientId(facesContext);
-			List<UploadedFile> uploadedFiles = uploadedFileMap.get(clientId);
 
-			if ((uploadedFiles != null) && (uploadedFiles.size() > 0)) {
+			if (uploadedFileMap.containsKey(clientId)) {
 
-				Part part = new HtmlInputFilePartImpl(uploadedFiles.get(0), clientId);
-				htmlInputFile.setTransient(true);
-				htmlInputFile.setSubmittedValue(part);
+				List<UploadedFile> uploadedFiles = uploadedFileMap.get(clientId);
+
+				if ((uploadedFiles != null) && (uploadedFiles.size() > 0)) {
+
+					Part part = new HtmlInputFilePartImpl(uploadedFiles.get(0), clientId);
+					htmlInputFile.setTransient(true);
+					htmlInputFile.setSubmittedValue(part);
+				}
+				else {
+					htmlInputFile.setSubmittedValue(new PartEmptyImpl());
+				}
 			}
-
-			// FACES-3136: Ensure that the required attribute is enforced.
-			else {
-				htmlInputFile.setSubmittedValue("");
-			}
-		}
-
-		// FACES-3136: Ensure that the required attribute is enforced.
-		else {
-			htmlInputFile.setSubmittedValue("");
 		}
 
 		RendererUtil.decodeClientBehaviors(facesContext, uiComponent);
+	}
+
+	@Override
+	public Object getConvertedValue(FacesContext facesContext, UIComponent uiComponent, Object submittedValue)
+		throws ConverterException {
+
+		if (submittedValue instanceof PartEmptyImpl) {
+			return null;
+		}
+		else {
+			return submittedValue;
+		}
 	}
 
 	@Override

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/component/inputfile/internal/InputFileRenderer.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/component/inputfile/internal/InputFileRenderer.java
@@ -17,6 +17,7 @@ package com.liferay.faces.bridge.component.inputfile.internal;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -78,13 +79,13 @@ public class InputFileRenderer extends InputFileRendererCompat {
 
 			// FACES-3136: Ensure that the required attribute is enforced.
 			else {
-				inputFile.setSubmittedValue("");
+				inputFile.setSubmittedValue(Collections.emptyList());
 			}
 		}
 
 		// FACES-3136: Ensure that the required attribute is enforced.
 		else {
-			inputFile.setSubmittedValue("");
+			inputFile.setSubmittedValue(Collections.emptyList());
 		}
 	}
 

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/component/inputfile/internal/PartEmptyImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/component/inputfile/internal/PartEmptyImpl.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.component.inputfile.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.servlet.http.Part;
+
+
+/**
+ * This is a marker class used by {@link HtmlInputFileRenderer} to signify that an empty file was submitted.
+ *
+ * @author  Kyle Stiemann
+ */
+public class PartEmptyImpl implements Part {
+
+	@Override
+	public void delete() throws IOException {
+		// no-op
+	}
+
+	@Override
+	public String getContentType() {
+		return null;
+	}
+
+	@Override
+	public String getHeader(String name) {
+		return null;
+	}
+
+	@Override
+	public Collection<String> getHeaderNames() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Collection<String> getHeaders(String name) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		throw new IOException("File does not exist.");
+	}
+
+	@Override
+	public String getName() {
+		return null;
+	}
+
+	@Override
+	public long getSize() {
+		return 0;
+	}
+
+	@Override
+	public void write(String fileName) throws IOException {
+		throw new IOException("File does not exist.");
+	}
+}

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/context/map/internal/MultiPartFormDataProcessorCompatImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/context/map/internal/MultiPartFormDataProcessorCompatImpl.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -132,6 +133,7 @@ public abstract class MultiPartFormDataProcessorCompatImpl {
 
 			if (fileItemIterator != null) {
 
+				List<String> fileUploadFieldNames = new ArrayList<String>();
 				int totalFiles = 0;
 
 				// For each field found in the request:
@@ -181,6 +183,8 @@ public abstract class MultiPartFormDataProcessorCompatImpl {
 							facesRequestParameterMap.addValue(fieldName, requestParameterValue);
 						}
 						else {
+
+							fileUploadFieldNames.add(fieldName);
 
 							File tempFile = diskFileItem.getStoreLocation();
 
@@ -267,6 +271,16 @@ public abstract class MultiPartFormDataProcessorCompatImpl {
 						com.liferay.faces.util.model.UploadedFile uploadedFile = uploadedFileFactory.getUploadedFile(e);
 						String fieldName = Integer.toString(totalFiles);
 						addUploadedFile(uploadedFileMap, fieldName, uploadedFile);
+					}
+				}
+
+				for (String fileUploadFieldName : fileUploadFieldNames) {
+
+					// Ensure that fields submitted without a file are present in the uploadedFileMap so that
+					// HtmlInputFileRenderer.decode() can determine whether or not the field was submitted with an empty
+					// value.
+					if (!uploadedFileMap.containsKey(fileUploadFieldName)) {
+						uploadedFileMap.put(fileUploadFieldName, Collections.<UploadedFile>emptyList());
 					}
 				}
 			}


### PR DESCRIPTION
@ngriffin7a, please backport this all the way. Note that `PartEmptyImpl.java` can be removed in the `2.x` backport.