### PR TITLE
FACES-3181 synchronization is used incorrectly (double-checked locking etc.) (fix static double-checked locking to synchronize on the class instead of an instance)

### DIFF
--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/event/internal/HeaderRequestPhaseListener.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/event/internal/HeaderRequestPhaseListener.java
@@ -38,7 +38,7 @@ public class HeaderRequestPhaseListener implements PhaseListener {
 	// serialVersionUID
 	private static final long serialVersionUID = 8470095938465172618L;
 
-	// Instance field must be declared volatile in order for the double-check idiom to work (requires JRE 1.5+)
+	// Static field must be declared volatile in order for the double-check idiom to work (requires JRE 1.5+)
 	private static volatile Boolean viewParametersEnabled;
 
 	@Override
@@ -49,7 +49,7 @@ public class HeaderRequestPhaseListener implements PhaseListener {
 		// First check without locking (not yet thread-safe)
 		if (viewParametersEnabled == null) {
 
-			synchronized (this) {
+			synchronized (HeaderRequestPhaseListener.class) {
 
 				// Second check with locking (thread-safe)
 				if (viewParametersEnabled == null) {


### PR DESCRIPTION
@ngriffin7a, please backport this commit to `5.x` **only**.