### PR TITLE
FACES-3220 Resource URL HTML encoded twice (clarify getAddToHeadSupport() return values)

### DIFF
--- a/bridge-impl/src/test/java/com/liferay/faces/bridge/context/BridgePortalContextAjaxRequestTest.java
+++ b/bridge-impl/src/test/java/com/liferay/faces/bridge/context/BridgePortalContextAjaxRequestTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.context;
+
+import javax.portlet.PortalContext;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.liferay.faces.bridge.context.internal.PortalContextBridgeImpl;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public class BridgePortalContextAjaxRequestTest {
+
+	@Test
+	public void testBridgePortalContextAjaxRequest() {
+
+		boolean markupHeadElementSupport = true;
+		boolean ajaxRequest = true;
+		PortalContext portalContextBridgeImpl = new PortalContextBridgeImpl(new PortletRequestMockImpl(
+					markupHeadElementSupport, ajaxRequest));
+		testBridgePortalContextAjaxRequest(portalContextBridgeImpl);
+
+		markupHeadElementSupport = false;
+		portalContextBridgeImpl = new PortalContextBridgeImpl(new PortletRequestMockImpl(markupHeadElementSupport,
+					ajaxRequest));
+		testBridgePortalContextAjaxRequest(portalContextBridgeImpl);
+	}
+
+	private void testBridgePortalContextAjaxRequest(PortalContext portalContextBridgeImpl) {
+
+		// During a Faces ajax request no elements can be added to the <head> section via the portlet API, so all
+		// *_HEAD_*_SUPPORT properties should return null.
+		Assert.assertNull(portalContextBridgeImpl.getProperty(PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT));
+		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT));
+		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_TEXT_TO_HEAD_SUPPORT));
+		Assert.assertNull(portalContextBridgeImpl.getProperty(
+				BridgePortalContext.ADD_STYLE_SHEET_RESOURCE_TO_HEAD_SUPPORT));
+		Assert.assertNull(portalContextBridgeImpl.getProperty(
+				BridgePortalContext.ADD_STYLE_SHEET_TEXT_TO_HEAD_SUPPORT));
+		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_ELEMENT_TO_HEAD_SUPPORT));
+	}
+}

--- a/bridge-impl/src/test/java/com/liferay/faces/bridge/context/BridgePortalContextTest.java
+++ b/bridge-impl/src/test/java/com/liferay/faces/bridge/context/BridgePortalContextTest.java
@@ -26,52 +26,24 @@ import com.liferay.faces.bridge.context.internal.PortalContextBridgeImpl;
 /**
  * @author  Kyle Stiemann
  */
-public class BridgePortalContextTest {
+public class BridgePortalContextTest extends BridgePortalContextTestCompat {
 
 	@Test
 	public void testBridgePortalContext() {
 
-		PortalContext portalContextBridgeImpl = new PortalContextBridgeImpl(new PortletRequestMockImpl(true, false));
+		// PortalContextBridgeImpl should delegate to the portlet container to determine if the optional
+		// MARKUP_HEAD_ELEMENT feature is supported.
+		boolean markupHeadElementSupport = true;
+		PortalContext portalContextBridgeImpl = new PortalContextBridgeImpl(new PortletRequestMockImpl(
+					markupHeadElementSupport));
 		Assert.assertEquals("true", portalContextBridgeImpl.getProperty(PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT));
-		Assert.assertEquals("true",
-			portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT));
-		Assert.assertEquals("true",
-			portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_TEXT_TO_HEAD_SUPPORT));
-		Assert.assertEquals("true",
-			portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_STYLE_SHEET_RESOURCE_TO_HEAD_SUPPORT));
-		Assert.assertEquals("true",
-			portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_STYLE_SHEET_TEXT_TO_HEAD_SUPPORT));
-		Assert.assertEquals("true",
-			portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_ELEMENT_TO_HEAD_SUPPORT));
+		testBridgePortalContextAddToHeadSupport(portalContextBridgeImpl, markupHeadElementSupport);
 
-		portalContextBridgeImpl = new PortalContextBridgeImpl(new PortletRequestMockImpl(false, false));
+		// PortalContextBridgeImpl should delegate to the portlet container to determine if the optional
+		// MARKUP_HEAD_ELEMENT feature is supported.
+		markupHeadElementSupport = false;
+		portalContextBridgeImpl = new PortalContextBridgeImpl(new PortletRequestMockImpl(markupHeadElementSupport));
 		Assert.assertNull(portalContextBridgeImpl.getProperty(PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_TEXT_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(
-				BridgePortalContext.ADD_STYLE_SHEET_RESOURCE_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(
-				BridgePortalContext.ADD_STYLE_SHEET_TEXT_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_ELEMENT_TO_HEAD_SUPPORT));
-
-		portalContextBridgeImpl = new PortalContextBridgeImpl(new PortletRequestMockImpl(true, true));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_TEXT_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(
-				BridgePortalContext.ADD_STYLE_SHEET_RESOURCE_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(
-				BridgePortalContext.ADD_STYLE_SHEET_TEXT_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_ELEMENT_TO_HEAD_SUPPORT));
-
-		portalContextBridgeImpl = new PortalContextBridgeImpl(new PortletRequestMockImpl(false, true));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_TEXT_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(
-				BridgePortalContext.ADD_STYLE_SHEET_RESOURCE_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(
-				BridgePortalContext.ADD_STYLE_SHEET_TEXT_TO_HEAD_SUPPORT));
-		Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_ELEMENT_TO_HEAD_SUPPORT));
+		testBridgePortalContextAddToHeadSupport(portalContextBridgeImpl, markupHeadElementSupport);
 	}
 }

--- a/bridge-impl/src/test/java/com/liferay/faces/bridge/context/BridgePortalContextTestCompat.java
+++ b/bridge-impl/src/test/java/com/liferay/faces/bridge/context/BridgePortalContextTestCompat.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.context;
+
+import javax.portlet.PortalContext;
+
+import org.junit.Assert;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public class BridgePortalContextTestCompat {
+
+	protected void testBridgePortalContextAddToHeadSupport(PortalContext portalContextBridgeImpl,
+		boolean markupHeadElementSupport) {
+
+		// BridgePortalContext.ADD_*_TO_HEAD_SUPPORT properties (such as ADD_ELEMENT_TO_HEAD_SUPPORT) can only be
+		// supported if the portlet container supports the MARKUP_HEAD_ELEMENT feature, so the
+		// BridgePortalContext.ADD_*_TO_HEAD_SUPPORT properties should return "true" if
+		// PortalContext.MARKUP_HEAD_ELEMENT_SUPPORT returns "true". Otherwise the properties should return null.
+		if (markupHeadElementSupport) {
+
+			Assert.assertEquals("true",
+				portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT));
+			Assert.assertEquals("true",
+				portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_TEXT_TO_HEAD_SUPPORT));
+			Assert.assertEquals("true",
+				portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_STYLE_SHEET_RESOURCE_TO_HEAD_SUPPORT));
+			Assert.assertEquals("true",
+				portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_STYLE_SHEET_TEXT_TO_HEAD_SUPPORT));
+			Assert.assertEquals("true",
+				portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_ELEMENT_TO_HEAD_SUPPORT));
+		}
+		else {
+
+			Assert.assertNull(portalContextBridgeImpl.getProperty(
+					BridgePortalContext.ADD_SCRIPT_RESOURCE_TO_HEAD_SUPPORT));
+			Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_SCRIPT_TEXT_TO_HEAD_SUPPORT));
+			Assert.assertNull(portalContextBridgeImpl.getProperty(
+					BridgePortalContext.ADD_STYLE_SHEET_RESOURCE_TO_HEAD_SUPPORT));
+			Assert.assertNull(portalContextBridgeImpl.getProperty(
+					BridgePortalContext.ADD_STYLE_SHEET_TEXT_TO_HEAD_SUPPORT));
+			Assert.assertNull(portalContextBridgeImpl.getProperty(BridgePortalContext.ADD_ELEMENT_TO_HEAD_SUPPORT));
+		}
+	}
+}

--- a/bridge-impl/src/test/java/com/liferay/faces/bridge/context/PortalContextMockImpl.java
+++ b/bridge-impl/src/test/java/com/liferay/faces/bridge/context/PortalContextMockImpl.java
@@ -17,8 +17,8 @@ package com.liferay.faces.bridge.context;
 
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.portlet.PortalContext;
 import javax.portlet.PortletMode;
@@ -31,21 +31,18 @@ import javax.portlet.WindowState;
 public class PortalContextMockImpl implements PortalContext {
 
 	// Private Data Members
-	private boolean markupHeadElementSupport;
-	private Enumeration<String> propertyNames;
+	private final Map<String, String> properties;
 
 	public PortalContextMockImpl(boolean markupHeadElementSupport) {
 
-		this.markupHeadElementSupport = markupHeadElementSupport;
-
 		if (markupHeadElementSupport) {
 
-			Set<String> propertyNames = new HashSet<String>();
-			propertyNames.add(MARKUP_HEAD_ELEMENT_SUPPORT);
-			this.propertyNames = Collections.enumeration(propertyNames);
+			Map<String, String> properties = new HashMap<String, String>();
+			properties.put(MARKUP_HEAD_ELEMENT_SUPPORT, "true");
+			this.properties = Collections.unmodifiableMap(properties);
 		}
 		else {
-			this.propertyNames = Collections.emptyEnumeration();
+			this.properties = Collections.emptyMap();
 		}
 	}
 
@@ -56,19 +53,12 @@ public class PortalContextMockImpl implements PortalContext {
 
 	@Override
 	public String getProperty(String name) {
-
-		String propertyValue = null;
-
-		if (markupHeadElementSupport && MARKUP_HEAD_ELEMENT_SUPPORT.equals(name)) {
-			propertyValue = "true";
-		}
-
-		return propertyValue;
+		return properties.get(name);
 	}
 
 	@Override
 	public Enumeration<String> getPropertyNames() {
-		return propertyNames;
+		return Collections.enumeration(properties.keySet());
 	}
 
 	@Override

--- a/bridge-impl/src/test/java/com/liferay/faces/bridge/context/PortletRequestMockCompatImpl.java
+++ b/bridge-impl/src/test/java/com/liferay/faces/bridge/context/PortletRequestMockCompatImpl.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-2017 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.bridge.context;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.faces.Bridge;
+
+
+/**
+ * @author  Kyle Stiemann
+ */
+public abstract class PortletRequestMockCompatImpl implements PortletRequest {
+
+	protected final Map<String, String[]> initParameters(boolean ajaxRequest) {
+
+		Map<String, String[]> parameters;
+
+		if (ajaxRequest) {
+
+			parameters = new HashMap<String, String[]>();
+			parameters.put(Bridge.FACES_AJAX_PARAMETER, new String[] { "true" });
+			parameters = Collections.unmodifiableMap(parameters);
+		}
+		else {
+			parameters = Collections.emptyMap();
+		}
+
+		return parameters;
+	}
+}

--- a/bridge-impl/src/test/java/com/liferay/faces/bridge/context/PortletRequestMockImpl.java
+++ b/bridge-impl/src/test/java/com/liferay/faces/bridge/context/PortletRequestMockImpl.java
@@ -18,7 +18,6 @@ package com.liferay.faces.bridge.context;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -28,32 +27,26 @@ import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletSession;
 import javax.portlet.WindowState;
-import javax.portlet.faces.Bridge;
 import javax.servlet.http.Cookie;
 
 
 /**
  * @author  Kyle Stiemann
  */
-public class PortletRequestMockImpl implements PortletRequest {
+public class PortletRequestMockImpl extends PortletRequestMockCompatImpl implements PortletRequest {
 
 	// Private Data Members
-	private Map<String, String[]> parameters;
-	private PortalContext portalContext;
+	private final Map<String, String[]> parameters;
+	private final PortalContext portalContext;
+
+	public PortletRequestMockImpl(boolean markupHeadElementSupport) {
+		this(markupHeadElementSupport, false);
+	}
 
 	public PortletRequestMockImpl(boolean markupHeadElementSupport, boolean ajaxRequest) {
 
 		this.portalContext = new PortalContextMockImpl(markupHeadElementSupport);
-
-		if (ajaxRequest) {
-
-			this.parameters = new HashMap<String, String[]>();
-			parameters.put(Bridge.FACES_AJAX_PARAMETER, new String[] { "true" });
-			parameters = Collections.unmodifiableMap(parameters);
-		}
-		else {
-			this.parameters = Collections.emptyMap();
-		}
+		this.parameters = initParameters(ajaxRequest);
 	}
 
 	@Override
@@ -111,7 +104,7 @@ public class PortletRequestMockImpl implements PortletRequest {
 
 	@Override
 	public Enumeration<String> getParameterNames() {
-		return Collections.<String>enumeration(parameters.keySet());
+		return Collections.enumeration(parameters.keySet());
 	}
 
 	@Override


### PR DESCRIPTION
@ngriffin7a, please merge this to `4.x` and backport to `3.x` **only**.