### PR TITLE
FIX FACES-3250: Primefaces-file-upload-mode=simple-does-not-work

### DIFF
--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/component/primefaces/internal/PrimeFacesFileUpload.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/component/primefaces/internal/PrimeFacesFileUpload.java
@@ -42,6 +42,7 @@ public class PrimeFacesFileUpload extends UIInputWrapper {
 
 	// Private Constants
 	private static final String METHOD_GET_MODE = "getMode";
+	private static final String METHOD_IS_SKIN_SIMPLE = "isSkinSimple";
 
 	// Private Data Members
 	private UIInput wrappedUIInput;
@@ -65,6 +66,22 @@ public class PrimeFacesFileUpload extends UIInputWrapper {
 
 		return mode;
 	}
+	
+	public boolean isSkinSimple() {
+		
+		boolean isSkinSimple = false;
+		Class<?> clazz = wrappedUIInput.getClass();
+
+		try {
+			Method method = clazz.getMethod(METHOD_IS_SKIN_SIMPLE, (Class[]) null);
+			isSkinSimple = (Boolean) method.invoke(wrappedUIInput, (Object[]) null);
+		} 
+		catch (Exception e) {
+			logger.error(e);
+		}
+
+		return isSkinSimple;
+	}	
 
 	@Override
 	public UIInput getWrapped() {

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/RenderKitBridgeImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/html_basic/internal/RenderKitBridgeImpl.java
@@ -87,7 +87,8 @@ public class RenderKitBridgeImpl extends RenderKitBridgeImplCompat {
 					renderer);
 		}
 		else if (PRIMEFACES_FAMILY.equals(family) && PrimeFacesFileUpload.RENDERER_TYPE.equals(rendererType)) {
-			renderer = new FileUploadRendererPrimeFacesImpl(renderer);
+			renderer = new FileUploadRendererPrimeFacesImpl(PRIMEFACES.getMajorVersion(), PRIMEFACES.getMinorVersion(),
+					renderer);
 		}
 		else if (RICHFACES_FILE_UPLOAD_FAMILY.equals(family) &&
 				RICHFACES_FILE_UPLOAD_RENDERER_TYPE.equals(rendererType)) {

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/primefaces/internal/FileUploadRendererPrimeFacesImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/primefaces/internal/FileUploadRendererPrimeFacesImpl.java
@@ -56,9 +56,13 @@ public class FileUploadRendererPrimeFacesImpl extends RendererWrapper {
 	private static final String FQCN_UPLOADED_FILE = "org.primefaces.model.UploadedFile";
 
 	// Private Data Members
+	private int majorVersion;
+	private int minorVersion;
 	private Renderer wrappedRenderer;
 
-	public FileUploadRendererPrimeFacesImpl(Renderer renderer) {
+	public FileUploadRendererPrimeFacesImpl(int majorVersion, int minorVersion, Renderer renderer) {
+		this.majorVersion = majorVersion;
+		this.minorVersion = minorVersion;
 		this.wrappedRenderer = renderer;
 	}
 
@@ -71,7 +75,7 @@ public class FileUploadRendererPrimeFacesImpl extends RendererWrapper {
 	public void decode(FacesContext facesContext, UIComponent uiComponent) {
 
 		try {
-			String clientId = uiComponent.getClientId(facesContext);
+			String clientId = getInputDecodeId(uiComponent, facesContext);
 			ExternalContext externalContext = facesContext.getExternalContext();
 			Map<String, String> requestParameterMap = externalContext.getRequestParameterMap();
 			String submittedValue = requestParameterMap.get(clientId);
@@ -135,5 +139,24 @@ public class FileUploadRendererPrimeFacesImpl extends RendererWrapper {
 	@Override
 	public Renderer getWrapped() {
 		return wrappedRenderer;
+	}
+	
+	public String getInputDecodeId(UIComponent uiComponent, FacesContext context) {
+		PrimeFacesFileUpload primeFacesFileUpload = new PrimeFacesFileUpload((UIInput) uiComponent);
+		String clientId = primeFacesFileUpload.getClientId(context);
+
+		// FACES-3250: Since PF 5.2
+		if (((majorVersion == 5) && (minorVersion >= 2)) || (majorVersion >= 6)) {
+			if (primeFacesFileUpload.getMode().equals(PrimeFacesFileUpload.MODE_SIMPLE)
+					&& primeFacesFileUpload.isSkinSimple()) {
+				return clientId + "_input";
+			} else {
+				return clientId;
+			}
+		}
+		// Older PF versions
+		else {
+			return clientId;
+		}
 	}
 }

--- a/issue/primefaces-issues-portlet/pom.xml
+++ b/issue/primefaces-issues-portlet/pom.xml
@@ -26,24 +26,32 @@
 	</profiles>
 
    <dependencies>
-      <dependency>
-         <groupId>javax.el</groupId>
-         <artifactId>javax.el-api</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>javax.portlet</groupId>
-         <artifactId>portlet-api</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>com.liferay.faces</groupId>
-         <artifactId>com.liferay.faces.bridge.impl</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.primefaces</groupId>
-         <artifactId>primefaces</artifactId>
-         <version>${primefaces.version}</version>
-      </dependency>
+	<dependency>
+		<groupId>commons-fileupload</groupId>
+		<artifactId>commons-fileupload</artifactId>
+	</dependency>
+	<dependency>
+		<groupId>commons-io</groupId>
+		<artifactId>commons-io</artifactId>
+	</dependency>
+	<dependency>
+		<groupId>javax.el</groupId>
+		<artifactId>javax.el-api</artifactId>
+	</dependency>
+	<dependency>
+		<groupId>javax.portlet</groupId>
+		<artifactId>portlet-api</artifactId>
+	</dependency>
+	<dependency>
+		<groupId>com.liferay.faces</groupId>
+		<artifactId>com.liferay.faces.bridge.impl</artifactId>
+		<version>${project.version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.primefaces</groupId>
+		<artifactId>primefaces</artifactId>
+		<version>${primefaces.version}</version>
+	</dependency>
    </dependencies>
 
 </project>

--- a/issue/primefaces-issues-portlet/src/main/java/com/liferay/faces/issue/primefaces/faces3250/AdvancedMode.java
+++ b/issue/primefaces-issues-portlet/src/main/java/com/liferay/faces/issue/primefaces/faces3250/AdvancedMode.java
@@ -1,0 +1,55 @@
+package com.liferay.faces.issue.primefaces.faces3250;
+
+import java.io.Serializable;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import org.primefaces.event.FileUploadEvent;
+import org.primefaces.model.UploadedFile;
+import com.liferay.faces.util.logging.Logger;
+import com.liferay.faces.util.logging.LoggerFactory;
+
+/**
+ * 
+ * @author Yeray Rodriguez (yerayrodriguez@gmail.com)
+ */
+@ManagedBean
+@SessionScoped
+public class AdvancedMode implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+	private static Logger logger = LoggerFactory.getLogger(AdvancedMode.class);
+
+	private UploadedFile file;
+	private String text;
+
+	public UploadedFile getFile() {
+		return file;
+	}
+
+	public void setFile(UploadedFile file) {
+		this.file = file;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public String getFileName() {
+		return file != null ? file.getFileName() : "empty";
+	}
+
+	public void submit() {
+		logger.info("Text: " + getText());
+		logger.info("Uploaded file: " + getFileName());
+	}
+
+	public void handleFileUpload(FileUploadEvent event) {
+		setFile(event.getFile());
+		logger.info("handleFileUpload:" + getFileName());
+	}
+
+}

--- a/issue/primefaces-issues-portlet/src/main/java/com/liferay/faces/issue/primefaces/faces3250/SimpleModeNoTheming.java
+++ b/issue/primefaces-issues-portlet/src/main/java/com/liferay/faces/issue/primefaces/faces3250/SimpleModeNoTheming.java
@@ -1,0 +1,49 @@
+package com.liferay.faces.issue.primefaces.faces3250;
+
+import java.io.Serializable;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import org.primefaces.model.UploadedFile;
+import com.liferay.faces.util.logging.Logger;
+import com.liferay.faces.util.logging.LoggerFactory;
+
+/**
+ * 
+ * @author Yeray Rodriguez (yerayrodriguez@gmail.com)
+ */
+@ManagedBean
+@SessionScoped
+public class SimpleModeNoTheming implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+	private static Logger logger = LoggerFactory.getLogger(SimpleModeNoTheming.class);
+
+	private UploadedFile file;
+	private String text;
+
+	public UploadedFile getFile() {
+		return file;
+	}
+
+	public void setFile(UploadedFile file) {
+		this.file = file;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public String getFileName() {
+		return file != null ? file.getFileName() : "empty";
+	}
+
+	public void submit() {
+		logger.info("Text: " + getText());
+		logger.info("Uploaded file: " + getFileName());
+	}
+
+}

--- a/issue/primefaces-issues-portlet/src/main/java/com/liferay/faces/issue/primefaces/faces3250/SimpleModeTheming.java
+++ b/issue/primefaces-issues-portlet/src/main/java/com/liferay/faces/issue/primefaces/faces3250/SimpleModeTheming.java
@@ -1,0 +1,49 @@
+package com.liferay.faces.issue.primefaces.faces3250;
+
+import java.io.Serializable;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import org.primefaces.model.UploadedFile;
+import com.liferay.faces.util.logging.Logger;
+import com.liferay.faces.util.logging.LoggerFactory;
+
+/**
+ * 
+ * @author Yeray Rodriguez (yerayrodriguez@gmail.com)
+ */
+@ManagedBean
+@SessionScoped
+public class SimpleModeTheming implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+	private static Logger logger = LoggerFactory.getLogger(SimpleModeTheming.class);
+
+	private UploadedFile file;
+	private String text;
+
+	public UploadedFile getFile() {
+		return file;
+	}
+
+	public void setFile(UploadedFile file) {
+		this.file = file;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public String getFileName() {
+		return file != null ? file.getFileName() : "empty";
+	}
+
+	public void submit() {
+		logger.info("Text: " + getText());
+		logger.info("Uploaded file: " + getFileName());
+	}
+
+}

--- a/issue/primefaces-issues-portlet/src/main/webapp/WEB-INF/liferay-display.xml
+++ b/issue/primefaces-issues-portlet/src/main/webapp/WEB-INF/liferay-display.xml
@@ -5,5 +5,6 @@
 	<category name="category.sample">
 		<portlet id="FACES-2921" />
 		<portlet id="FACES-3031" />
+		<portlet id="FACES-3250" />
 	</category>
 </display>

--- a/issue/primefaces-issues-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml
+++ b/issue/primefaces-issues-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml
@@ -14,6 +14,12 @@
 		<instanceable>false</instanceable>
 		<ajaxable>false</ajaxable>
 	</portlet>
+	
+	<portlet>
+		<portlet-name>FACES-3250</portlet-name>
+		<instanceable>false</instanceable>
+		<ajaxable>false</ajaxable>
+	</portlet>	
 
 	<role-mapper>
 		<role-name>administrator</role-name>

--- a/issue/primefaces-issues-portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/issue/primefaces-issues-portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -64,4 +64,35 @@
 			<role-name>user</role-name>
 		</security-role-ref>
 	</portlet>
+	
+	<portlet>
+		<portlet-name>FACES-3250</portlet-name>
+		<display-name>FACES-3250</display-name>
+		<portlet-class>javax.portlet.faces.GenericFacesPortlet</portlet-class>
+		<init-param>
+			<name>javax.portlet.faces.defaultViewId.view</name>
+			<value>/WEB-INF/views/FACES-3250/view.xhtml</value>
+		</init-param>
+		<expiration-cache>0</expiration-cache>
+		<supports>
+			<mime-type>text/html</mime-type>
+		</supports>
+		<portlet-info>
+			<title>FACES-3250</title>
+			<short-title>FACES-3250</short-title>
+			<keywords>FACES-3250</keywords>
+		</portlet-info>
+		<security-role-ref>
+			<role-name>administrator</role-name>
+		</security-role-ref>
+		<security-role-ref>
+			<role-name>guest</role-name>
+		</security-role-ref>
+		<security-role-ref>
+			<role-name>power-user</role-name>
+		</security-role-ref>
+		<security-role-ref>
+			<role-name>user</role-name>
+		</security-role-ref>
+	</portlet>	
 </portlet-app>

--- a/issue/primefaces-issues-portlet/src/main/webapp/WEB-INF/views/FACES-3250/view.xhtml
+++ b/issue/primefaces-issues-portlet/src/main/webapp/WEB-INF/views/FACES-3250/view.xhtml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+
+<f:view xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:p="http://primefaces.org/ui">
+	<h:head>
+	</h:head>
+	<h:body>
+		<h:form id="formSimpleNoTheming" enctype="multipart/form-data">
+			<h:outputText value="Simple mode, without theming (skinSimple=false)" />
+			<br />
+			<p:inputText id="inputTextSimpleModeNoTheming"
+				value="#{simpleModeNoTheming.text}" />
+			<br />
+			<p:fileUpload id="fileUploadSimpleModeNoTheming"
+				value="#{simpleModeNoTheming.file}" mode="simple" skinSimple="false" />
+			<br />
+			<p:commandButton id="submitSimpleModeNoTheming" value="Submit"
+				ajax="false" actionListener="#{simpleModeNoTheming.submit}" />
+			<br />
+			<h:outputText value="Text: " />
+			<h:outputText id="outputTextSimpleModeNoTheming"
+				value="#{simpleModeNoTheming.text}" />
+			<br />
+			<h:outputText value="Uploaded file name: " />
+			<h:outputText id="fileNameSimpleModeNoTheming"
+				value="#{simpleModeNoTheming.fileName}" />
+		</h:form>
+		<hr />
+		<h:form id="formSimpleTheming" enctype="multipart/form-data">
+			<h:outputText value="Simple mode, with theming (skinSimple=true)" />
+			<br />
+			<p:inputText id="inputTextSimpleModeTheming"
+				value="#{simpleModeTheming.text}" />
+			<br />
+			<p:fileUpload id="fileUploadSimpleModeTheming"
+				value="#{simpleModeTheming.file}" mode="simple" skinSimple="true" />
+			<br />
+			<p:commandButton id="submitSimpleModeTheming" value="Submit"
+				ajax="false" actionListener="#{simpleModeTheming.submit}" />
+			<br />
+			<h:outputText value="Text: " />
+			<h:outputText id="outputTextSimpleModeTheming"
+				value="#{simpleModeTheming.text}" />
+			<br />
+			<h:outputText value="Uploaded file name: " />
+			<h:outputText id="fileNameSimpleModeTheming"
+				value="#{simpleModeTheming.fileName}" />
+		</h:form>
+		<hr />
+		<h:form id="formAdvanced" enctype="multipart/form-data">
+			<h:outputText value="Advanced mode" />
+			<br />
+			<p:inputText id="inputTextAdvancedMode" value="#{advancedMode.text}" />
+			<br />
+			<p:fileUpload id="fileUploadAdvancedMode"
+				fileUploadListener="#{advancedMode.handleFileUpload}"
+				mode="advanced" multiple="false" auto="true" />
+			<br />
+			<p:commandButton id="submitAdvancedMode" value="Submit" ajax="false"
+				actionListener="#{advancedMode.submit}" />
+			<br />
+			<h:outputText value="Text: " />
+			<h:outputText id="outputTextAdvancedMode"
+				value="#{advancedMode.text}" />
+			<br />
+			<h:outputText value="Uploaded file name: " />
+			<h:outputText id="fileNameAdvancedMode"
+				value="#{advancedMode.fileName}" />
+		</h:form>
+		<hr />
+		<ul>
+			<li><em><h:outputText value="#{product.JSF}" /></em></li>
+			<li><em><h:outputText value="#{product.PRIMEFACES}" /></em></li>
+			<li><em><h:outputText
+						value="#{product.LIFERAY_FACES_BRIDGE}" /></em></li>
+			<li><em><h:outputText value="#{product.PORTLET_API}" /></em></li>
+			<li><em><h:outputText value="#{product.PORTLET_CONTAINER}" /></em></li>
+			<li><em><h:outputText value="#{product.SERVLET_CONTAINER}" /></em></li>
+		</ul>
+	</h:body>
+</f:view>


### PR DESCRIPTION
Since PF 5.2 ([1](https://github.com/primefaces/primefaces/commit/49d0c7810c2ee1dae8cddf6f09ecc4c084b1fcc1)) ([2](https://github.com/primefaces/primefaces/commit/9cc0236268497c8b44feda4f6c81bff9e7ed2b65)) ([3](https://github.com/primefaces/primefaces/commit/858b0f72cba30bee3e8bfe1ddb0321d9f4538da4)) it is needed to adjust clientId of fileUpload component when mode=simple and skinSimple=true. 

Tested on LF 6.2.3 with PF 5.1, 5.2, 5.3, 6.0 and 6.1 using [this portlet](https://github.com/yerayrodriguez/primefaces-fileupload-test-portlet), which implements 3 upload modes:

- Simple mode without theming (skinSimple="false")
- Simple mode with theming (skinSimple="true")
- Advanced mode