### PR TITLE
FACES-3327 PrimeFaces exporter components (p:fileDownload, p:dataExporter, and pe:exporter) cause next navigation to fail

### DIFF
--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/internal/BridgeExt.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/internal/BridgeExt.java
@@ -21,6 +21,7 @@ package com.liferay.faces.bridge.internal;
 public interface BridgeExt {
 
 	public static final String BOOKMARKABLE_PARAMETER = "_jsfBridgeBookmarkable";
+	public static final String FACES_EXPORT_COMPONENT_PARAMETER = "_jsfExportComponent";
 	public static final String REDIRECT_PARAMETER = "_jsfBridgeRedirect";
 	public static final String RENDER_REDIRECT = "com.liferay.faces.bridge.renderRedirect";
 	public static final String RENDER_REDIRECT_AFTER_DISPATCH = "com.liferay.faces.bridge.renderRedirectAfterDispatch";

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/internal/BridgePhaseBaseImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/internal/BridgePhaseBaseImpl.java
@@ -234,6 +234,15 @@ public abstract class BridgePhaseBaseImpl implements BridgePhase {
 				bridgeRequestScopeEnabled = PortletConfigParam.BridgeRequestScopeAjaxEnabled.getBooleanValue(
 						portletConfig);
 			}
+			else {
+
+				String facesExportComponentParameter = portletRequest.getParameter(
+						BridgeExt.FACES_EXPORT_COMPONENT_PARAMETER);
+
+				if (BooleanHelper.isTrueToken(facesExportComponentParameter)) {
+					bridgeRequestScopeEnabled = false;
+				}
+			}
 		}
 
 		if (bridgeRequestScopeEnabled) {

--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/primefaces/internal/FormRendererPrimeFacesImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/renderkit/primefaces/internal/FormRendererPrimeFacesImpl.java
@@ -35,6 +35,7 @@ import javax.portlet.faces.BridgeFactoryFinder;
 import javax.portlet.faces.BridgeURL;
 import javax.portlet.faces.BridgeURLFactory;
 
+import com.liferay.faces.bridge.internal.BridgeExt;
 import com.liferay.faces.bridge.renderkit.html_basic.internal.RenderKitBridgeImpl;
 
 
@@ -112,6 +113,7 @@ public class FormRendererPrimeFacesImpl extends RendererWrapper {
 			try {
 				BridgeURL partialActionURL = bridgeURLFactory.getBridgePartialActionURL(facesContext, facesActionURL);
 				partialActionURL.removeParameter(Bridge.FACES_AJAX_PARAMETER);
+				partialActionURL.setParameter(BridgeExt.FACES_EXPORT_COMPONENT_PARAMETER, "true");
 
 				String nonAjaxPartialActionURL = partialActionURL.toString();
 				ResponseWriter responseWriter = facesContext.getResponseWriter();


### PR DESCRIPTION
@ngriffin7a. Please review this and backport to 5.x and 4.x. Note that I committed and pushed the reproducer separately.