### PR TITLE
Enable building demo applications

### DIFF
--- a/demo/alloy-applicant-portlet/pom.xml
+++ b/demo/alloy-applicant-portlet/pom.xml
@@ -79,6 +79,10 @@
 			<groupId>jakarta.annotation</groupId>
 			<artifactId>jakarta.annotation-api</artifactId>
 		</dependency>
+                <dependency>
+                    <groupId>com.liferay</groupId>
+                    <artifactId>com.liferay.faces.util</artifactId>
+                </dependency>
 	</dependencies>
 
 </project>

--- a/demo/jsf-applicant-portlet/pom.xml
+++ b/demo/jsf-applicant-portlet/pom.xml
@@ -79,6 +79,10 @@
 			<groupId>com.liferay</groupId>
 			<artifactId>com.liferay.faces.alloy</artifactId>
 		</dependency>
+                <dependency>
+                    <groupId>com.liferay</groupId>
+                    <artifactId>com.liferay.faces.util</artifactId>
+                </dependency>
 	</dependencies>
 
 </project>

--- a/demo/jsf-cdi-applicant-portlet/pom.xml
+++ b/demo/jsf-cdi-applicant-portlet/pom.xml
@@ -176,6 +176,10 @@ com.sun.faces.flow.FlowDiscoveryCDIExtension
 			<groupId>com.liferay</groupId>
 			<artifactId>com.liferay.faces.alloy</artifactId>
 		</dependency>
+                <dependency>
+                    <groupId>com.liferay</groupId>
+                    <artifactId>com.liferay.faces.util</artifactId>
+                </dependency>
 	</dependencies>
 
 </project>

--- a/demo/jsf-flows-portlet/pom.xml
+++ b/demo/jsf-flows-portlet/pom.xml
@@ -160,6 +160,10 @@ com.sun.faces.flow.FlowDiscoveryCDIExtension
 			<groupId>com.liferay.jakarta.portlet</groupId>
 			<artifactId>com.liferay.jakarta.portlet-api</artifactId>
 		</dependency>
+                <dependency>
+                    <groupId>com.liferay</groupId>
+                    <artifactId>com.liferay.faces.util</artifactId>
+                </dependency>
 	</dependencies>
 
 </project>

--- a/demo/jsf-html5-applicant-portlet/pom.xml
+++ b/demo/jsf-html5-applicant-portlet/pom.xml
@@ -79,6 +79,10 @@
 			<groupId>jakarta.annotation</groupId>
 			<artifactId>jakarta.annotation-api</artifactId>
 		</dependency>
+                <dependency>
+                    <groupId>com.liferay</groupId>
+                    <artifactId>com.liferay.faces.util</artifactId>
+                </dependency>
 	</dependencies>
 
 </project>

--- a/demo/jsf-showcase-portlet/pom.xml
+++ b/demo/jsf-showcase-portlet/pom.xml
@@ -107,6 +107,10 @@
 			<groupId>jakarta.inject</groupId>
 			<artifactId>jakarta.inject-api</artifactId>
 		</dependency>
+                <dependency>
+                    <groupId>com.liferay</groupId>
+                    <artifactId>com.liferay.faces.util</artifactId>
+                </dependency>
 	</dependencies>
 
 	<!-- Note that this pom.xml provides similar functionality as the maven-assembly-plugin -->

--- a/demo/primefaces-applicant-portlet/pom.xml
+++ b/demo/primefaces-applicant-portlet/pom.xml
@@ -87,6 +87,10 @@
 			<groupId>jakarta.annotation</groupId>
 			<artifactId>jakarta.annotation-api</artifactId>
 		</dependency>
-	</dependencies>
+                <dependency>
+                    <groupId>com.liferay</groupId>
+                    <artifactId>com.liferay.faces.util</artifactId>
+                </dependency>
+        </dependencies>
 
 </project>


### PR DESCRIPTION
- dependency on com.liferay.faces.util is missing for the demos:
  - alloy-applicant-portlet
  - jsf-applicant-portlet
  - jsf-cdi-applicant-portlet
  - jsf-flows-portlet
  - jsf-html5-applicant-portlet
  - jsf-showcase-portlet
  - primefaces-applicant-portlet

Dependencies:
- com.liferay.faces.demo.showcase.common
- com.liferay.faces.demo.jsf.showcase.webapp

can not be found and need to be manually built from liferay-faces-showcase repository: https://github.com/liferay/liferay-faces-showcase.

The show case needs be modified to include the Liferay Maven repositories in the pom.xml to be buildable.

Dependencies:
- com.liferay.faces.alloy.reslib
- com.liferay.faces.demo.alloy.showcase.webapp

can not be found and need to be manually built from liferay-faces-alloy repository: https://github.com/liferay/liferay-faces-alloy

This PR does not claim that the demos work correctly. jsf-applicant-portlet, primefaces-applicant-portlet were tested and seem to work correctly, jsf-showcase-portlet loads, but accordion collapse does not work correctly (accordions open and immediately collapse after they opened).